### PR TITLE
Fix name attribute in wildthumper_playpen world

### DIFF
--- a/Ignition/worlds/wildthumper_playpen.sdf
+++ b/Ignition/worlds/wildthumper_playpen.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
-  <world name="wildthumper_runway">
+  <world name="wildthumper_playpen">
     <plugin filename="libignition-gazebo-physics-system.so"
       name="ignition::gazebo::systems::Physics">
     </plugin>


### PR DESCRIPTION
This PR corrects the name attribute of the playpen world example.