### PR TITLE
Gazebo: enable models to be used in ROS 2 launch scripts

### DIFF
--- a/Gazebo/CMakeLists.txt
+++ b/Gazebo/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.5)
+project(ardupilot_sitl_models)
+
+# --------------------------------------------------------------------------- #
+# Find dependencies.
+find_package(ament_cmake REQUIRED)
+
+find_package(gz-cmake3 REQUIRED)
+
+find_package(gz-sim7 REQUIRED)
+set(GZ_SIM_VER ${gz-sim7_VERSION_MAJOR})
+
+# --------------------------------------------------------------------------- #
+#  Build.
+
+# --------------------------------------------------------------------------- #
+#  Install.
+
+# Install project configuration files.
+install(
+  DIRECTORY
+    config/
+  DESTINATION share/${PROJECT_NAME}/config
+)
+
+# Install project model files.
+install(
+  DIRECTORY models/
+  DESTINATION share/${PROJECT_NAME}/models
+)
+
+# Install project world files.
+install(
+  DIRECTORY worlds/
+  DESTINATION share/${PROJECT_NAME}/worlds
+)
+
+# --------------------------------------------------------------------------- #
+#  Build tests.
+
+if(BUILD_TESTING)
+  # Override default flake8 configuration.
+  set(ament_cmake_flake8_CONFIG_FILE ${CMAKE_SOURCE_DIR}/.flake8)
+
+  # Add linters.
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+# --------------------------------------------------------------------------- #
+#  Environment hooks.
+
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/${PROJECT_NAME}.dsv.in")
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/${PROJECT_NAME}.sh.in")
+
+# --------------------------------------------------------------------------- #
+#  Call last.
+
+ament_package()

--- a/Gazebo/hooks/ardupilot_sitl_models.dsv.in
+++ b/Gazebo/hooks/ardupilot_sitl_models.dsv.in
@@ -1,0 +1,4 @@
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share;@CMAKE_INSTALL_PREFIX@/share
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share/@PROJECT_NAME@/models
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share/@PROJECT_NAME@/worlds
+prepend-non-duplicate;GZ_SIM_SYSTEM_PLUGIN_PATH;lib/@PROJECT_NAME@/

--- a/Gazebo/hooks/ardupilot_sitl_models.sh.in
+++ b/Gazebo/hooks/ardupilot_sitl_models.sh.in
@@ -1,0 +1,3 @@
+ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
+ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds"
+ament_prepend_unique_value GZ_SIM_PLUGIN_PATH "$AMENT_CURRENT_PREFIX/lib/@PROJECT_NAME@"

--- a/Gazebo/models/wildthumper/model.sdf
+++ b/Gazebo/models/wildthumper/model.sdf
@@ -1765,6 +1765,13 @@
     <plugin filename="libgz-sim-joint-state-publisher-system.so"
       name="gz::sim::systems::JointStatePublisher">
     </plugin>
+    <plugin
+      filename="gz-sim-odometry-publisher-system"
+      name="gz::sim::systems::OdometryPublisher">
+      <odom_frame>odom</odom_frame>
+      <robot_base_frame>base_link</robot_base_frame>
+      <dimensions>3</dimensions>
+    </plugin>
     <plugin filename="libgz-sim-apply-joint-force-system.so"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>front_left_wheel_joint</joint_name>

--- a/Gazebo/package.xml
+++ b/Gazebo/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ardupilot_sitl_models</name>
+  <version>0.0.0</version>
+  <description>Gazebo models configured for ArduPilot SITL</description>
+  <maintainer email="rhys.mainwaring@me.com">Rhys Mainwaring</maintainer>
+  <license>GPL-3.0</license>
+  <author>Rhys Mainwaring</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <exec_depend>ardupilot_gazebo</exec_depend>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>
+

--- a/Gazebo/worlds/wildthumper_playpen.sdf
+++ b/Gazebo/worlds/wildthumper_playpen.sdf
@@ -1,8 +1,18 @@
 <?xml version="1.0" ?>
-<sdf version="1.7">
-  <world name="wildthumper_playpen">
+<sdf version="1.9">
+  <world name="playpen">
+    <physics name="1ms" type="ignore">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+
     <plugin filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin
+      filename="gz-sim-sensors-system"
+      name="gz::sim::systems::Sensors">
+      <render_engine>ogre2</render_engine>
     </plugin>
     <plugin filename="gz-sim-user-commands-system"
       name="gz::sim::systems::UserCommands">
@@ -12,6 +22,12 @@
     </plugin>
     <plugin filename="gz-sim-imu-system"
       name="gz::sim::systems::Imu">
+    </plugin>
+    <plugin filename="gz-sim-magnetometer-system"
+      name="gz::sim::systems::Magnetometer">
+    </plugin>
+    <plugin filename="gz-sim-navsat-system"
+      name="gz::sim::systems::NavSat">
     </plugin>
 
     <scene>
@@ -34,12 +50,21 @@
       <direction>-0.5 0.1 -0.9</direction>
     </light>
 
+    <spherical_coordinates>
+      <latitude_deg>-35.3632621</latitude_deg>
+      <longitude_deg>149.1652374</longitude_deg>
+      <elevation>10.0</elevation>
+      <heading_deg>0</heading_deg>
+      <surface_model>EARTH_WGS84</surface_model>
+    </spherical_coordinates>
+
     <include>
+      <pose degrees="true">0 0 0 0 0 0</pose>
       <uri>model://rover_playpen</uri>
     </include>
 
     <include>
-      <pose>0 0 0.15 0 0 0</pose>
+      <pose degrees="true">0 0 0.15 0 0 0</pose>
       <uri>model://wildthumper</uri>
     </include>
 


### PR DESCRIPTION
Add a `CMakeLists.txt` and `package.xml` to enable this package to be included in `colcon` workspaces. The hooks allow `colcon` to configure the environment correctly so the model and world files will be found.


### Other changes

- Update the `wildthumper_playpen` world with additional sensor plugins and a spherical coordinate location.
- Add odometry plugin to the `wildthumper` model.
 
### See also

- https://github.com/ArduPilot/ardupilot_gz/pull/33