### PR TITLE
Gazebo: remove unnecessary dependency on gz-sim

### DIFF
--- a/Gazebo/CMakeLists.txt
+++ b/Gazebo/CMakeLists.txt
@@ -5,11 +5,6 @@ project(ardupilot_sitl_models)
 # Find dependencies.
 find_package(ament_cmake REQUIRED)
 
-find_package(gz-cmake3 REQUIRED)
-
-find_package(gz-sim7 REQUIRED)
-set(GZ_SIM_VER ${gz-sim7_VERSION_MAJOR})
-
 # --------------------------------------------------------------------------- #
 #  Build.
 


### PR DESCRIPTION
The cmake build of SITL_Models does not require the dependency on `gz-sim` or `gz-cmake` as there are no binaries to build. These dependencies cause an issue when building for Gazebo Harmonic, so remove.