### PR TITLE
Gazebo: disable moment coefficient contribution

### DIFF
--- a/Gazebo/models/alti_transition_quad/model.sdf
+++ b/Gazebo/models/alti_transition_quad/model.sdf
@@ -749,7 +749,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -766,7 +766,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -784,7 +784,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -801,7 +801,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -819,7 +819,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -836,7 +836,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -854,7 +854,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -871,7 +871,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -889,7 +889,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -906,7 +906,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -923,11 +923,11 @@
       <a0>0.13</a0>
       <cla>3.7</cla>
       <cda>0.06417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>0.02 0 0.021946</cp>
       <area>0.8306432</area>
       <air_density>1.2041</air_density>
@@ -941,11 +941,11 @@
       <a0>0.15</a0>
       <cla>6.8</cla>
       <cda>0.06417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.6391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.161120956 1.116470319 0.073423477</cp>
       <area>0.031165499</area>
       <air_density>1.2041</air_density>
@@ -961,11 +961,11 @@
       <a0>0.15</a0>
       <cla>6.8</cla>
       <cda>0.06417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.6391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.161120956 -1.116470319 0.073423477</cp>
       <area>0.031165499</area>
       <air_density>1.2041</air_density>
@@ -981,11 +981,11 @@
       <a0>0.0</a0>
       <cla>4.752798721</cla>
       <cda>0.6417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.19 1.46 0.15</cp>
       <area>0.0152</area>
       <air_density>1.2041</air_density>
@@ -999,11 +999,11 @@
       <a0>0.0</a0>
       <cla>4.752798721</cla>
       <cda>0.6417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.19 -1.46 0.15</cp>
       <area>0.0152</area>
       <air_density>1.2041</air_density>
@@ -1017,11 +1017,11 @@
       <a0>0.13</a0>
       <cla>3.7</cla>
       <cda>0.06417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-1.383506602 0 0.213284959</cp>
       <area>0.0864</area>
       <air_density>1.2041</air_density>
@@ -1035,11 +1035,11 @@
       <a0>0.15</a0>
       <cla>6.8</cla>
       <cda>0.06417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.6391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-1.383506602 0 0.213284959</cp>
       <area>0.02376</area>
       <air_density>1.2041</air_density>
@@ -1055,11 +1055,11 @@
       <a0>0.0</a0>
       <cla>4.752798721</cla>
       <cda>0.6417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-1.25 0.405 0.1</cp>
       <area>0.0378</area>
       <air_density>1.2041</air_density>
@@ -1073,11 +1073,11 @@
       <a0>0.0</a0>
       <cla>4.752798721</cla>
       <cda>0.6417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-1.25 -0.405 0.1</cp>
       <area>0.0378</area>
       <air_density>1.2041</air_density>

--- a/Gazebo/models/alti_transition_quad/model.sdf.erb
+++ b/Gazebo/models/alti_transition_quad/model.sdf.erb
@@ -770,7 +770,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <alpha_stall>1.4</alpha_stall>
     <cla>4.2500</cla>
     <cda>0.10</cda>
-    <cma>0.00</cma>
+    <cma>0.0</cma>
     <cla_stall>-0.025</cla_stall>
     <cda_stall>0.0</cda_stall>
     <cma_stall>0.0</cma_stall>
@@ -787,7 +787,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <alpha_stall>1.4</alpha_stall>
     <cla>4.2500</cla>
     <cda>0.10</cda>
-    <cma>0.00</cma>
+    <cma>0.0</cma>
     <cla_stall>-0.025</cla_stall>
     <cda_stall>0.0</cda_stall>
     <cma_stall>0.0</cma_stall>
@@ -805,7 +805,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <alpha_stall>1.4</alpha_stall>
     <cla>4.2500</cla>
     <cda>0.10</cda>
-    <cma>0.00</cma>
+    <cma>0.0</cma>
     <cla_stall>-0.025</cla_stall>
     <cda_stall>0.0</cda_stall>
     <cma_stall>0.0</cma_stall>
@@ -822,7 +822,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <alpha_stall>1.4</alpha_stall>
     <cla>4.2500</cla>
     <cda>0.10</cda>
-    <cma>0.00</cma>
+    <cma>0.0</cma>
     <cla_stall>-0.025</cla_stall>
     <cda_stall>0.0</cda_stall>
     <cma_stall>0.0</cma_stall>
@@ -840,7 +840,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <alpha_stall>1.4</alpha_stall>
     <cla>4.2500</cla>
     <cda>0.10</cda>
-    <cma>0.00</cma>
+    <cma>0.0</cma>
     <cla_stall>-0.025</cla_stall>
     <cda_stall>0.0</cda_stall>
     <cma_stall>0.0</cma_stall>
@@ -857,7 +857,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <alpha_stall>1.4</alpha_stall>
     <cla>4.2500</cla>
     <cda>0.10</cda>
-    <cma>0.00</cma>
+    <cma>0.0</cma>
     <cla_stall>-0.025</cla_stall>
     <cda_stall>0.0</cda_stall>
     <cma_stall>0.0</cma_stall>
@@ -875,7 +875,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <alpha_stall>1.4</alpha_stall>
     <cla>4.2500</cla>
     <cda>0.10</cda>
-    <cma>0.00</cma>
+    <cma>0.0</cma>
     <cla_stall>-0.025</cla_stall>
     <cda_stall>0.0</cda_stall>
     <cma_stall>0.0</cma_stall>
@@ -892,7 +892,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <alpha_stall>1.4</alpha_stall>
     <cla>4.2500</cla>
     <cda>0.10</cda>
-    <cma>0.00</cma>
+    <cma>0.0</cma>
     <cla_stall>-0.025</cla_stall>
     <cda_stall>0.0</cda_stall>
     <cma_stall>0.0</cma_stall>
@@ -910,7 +910,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <alpha_stall>1.4</alpha_stall>
     <cla>4.2500</cla>
     <cda>0.10</cda>
-    <cma>0.00</cma>
+    <cma>0.0</cma>
     <cla_stall>-0.025</cla_stall>
     <cda_stall>0.0</cda_stall>
     <cma_stall>0.0</cma_stall>
@@ -927,7 +927,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <alpha_stall>1.4</alpha_stall>
     <cla>4.2500</cla>
     <cda>0.10</cda>
-    <cma>0.00</cma>
+    <cma>0.0</cma>
     <cla_stall>-0.025</cla_stall>
     <cda_stall>0.0</cda_stall>
     <cma_stall>0.0</cma_stall>
@@ -944,11 +944,11 @@ DO NOT EDIT. This file is generated from an ERB template.
     <a0>0.13</a0>
     <cla>3.7</cla>
     <cda>0.06417112299</cda>
-    <cma>-1.8</cma>
+    <cma>0.0</cma>
     <alpha_stall>0.3391428111</alpha_stall>
     <cla_stall>-3.85</cla_stall>
     <cda_stall>-0.9233984055</cda_stall>
-    <cma_stall>0</cma_stall>
+    <cma_stall>0.0</cma_stall>
     <cp>0.02 0 0.021946</cp>
     <area>0.8306432</area>
     <air_density>1.2041</air_density>
@@ -962,11 +962,11 @@ DO NOT EDIT. This file is generated from an ERB template.
     <a0>0.15</a0>
     <cla>6.8</cla>
     <cda>0.06417112299</cda>
-    <cma>-1.8</cma>
+    <cma>0.0</cma>
     <alpha_stall>0.6391428111</alpha_stall>
     <cla_stall>-3.85</cla_stall>
     <cda_stall>-0.9233984055</cda_stall>
-    <cma_stall>0</cma_stall>
+    <cma_stall>0.0</cma_stall>
     <cp>-0.161120956 1.116470319 0.073423477</cp>
     <area>0.031165499</area>
     <air_density>1.2041</air_density>
@@ -982,11 +982,11 @@ DO NOT EDIT. This file is generated from an ERB template.
     <a0>0.15</a0>
     <cla>6.8</cla>
     <cda>0.06417112299</cda>
-    <cma>-1.8</cma>
+    <cma>0.0</cma>
     <alpha_stall>0.6391428111</alpha_stall>
     <cla_stall>-3.85</cla_stall>
     <cda_stall>-0.9233984055</cda_stall>
-    <cma_stall>0</cma_stall>
+    <cma_stall>0.0</cma_stall>
     <cp>-0.161120956 -1.116470319 0.073423477</cp>
     <area>0.031165499</area>
     <air_density>1.2041</air_density>
@@ -1002,11 +1002,11 @@ DO NOT EDIT. This file is generated from an ERB template.
     <a0>0.0</a0>
     <cla>4.752798721</cla>
     <cda>0.6417112299</cda>
-    <cma>-1.8</cma>
+    <cma>0.0</cma>
     <alpha_stall>0.3391428111</alpha_stall>
     <cla_stall>-3.85</cla_stall>
     <cda_stall>-0.9233984055</cda_stall>
-    <cma_stall>0</cma_stall>
+    <cma_stall>0.0</cma_stall>
     <cp>-0.19 1.46 0.15</cp>
     <area>0.0152</area>
     <air_density>1.2041</air_density>
@@ -1020,11 +1020,11 @@ DO NOT EDIT. This file is generated from an ERB template.
     <a0>0.0</a0>
     <cla>4.752798721</cla>
     <cda>0.6417112299</cda>
-    <cma>-1.8</cma>
+    <cma>0.0</cma>
     <alpha_stall>0.3391428111</alpha_stall>
     <cla_stall>-3.85</cla_stall>
     <cda_stall>-0.9233984055</cda_stall>
-    <cma_stall>0</cma_stall>
+    <cma_stall>0.0</cma_stall>
     <cp>-0.19 -1.46 0.15</cp>
     <area>0.0152</area>
     <air_density>1.2041</air_density>
@@ -1038,11 +1038,11 @@ DO NOT EDIT. This file is generated from an ERB template.
     <a0>0.13</a0>
     <cla>3.7</cla>
     <cda>0.06417112299</cda>
-    <cma>-1.8</cma>
+    <cma>0.0</cma>
     <alpha_stall>0.3391428111</alpha_stall>
     <cla_stall>-3.85</cla_stall>
     <cda_stall>-0.9233984055</cda_stall>
-    <cma_stall>0</cma_stall>
+    <cma_stall>0.0</cma_stall>
     <cp>-1.383506602 0 0.213284959</cp>
     <area>0.0864</area>
     <air_density>1.2041</air_density>
@@ -1056,11 +1056,11 @@ DO NOT EDIT. This file is generated from an ERB template.
     <a0>0.15</a0>
     <cla>6.8</cla>
     <cda>0.06417112299</cda>
-    <cma>-1.8</cma>
+    <cma>0.0</cma>
     <alpha_stall>0.6391428111</alpha_stall>
     <cla_stall>-3.85</cla_stall>
     <cda_stall>-0.9233984055</cda_stall>
-    <cma_stall>0</cma_stall>
+    <cma_stall>0.0</cma_stall>
     <cp>-1.383506602 0 0.213284959</cp>
     <area>0.02376</area>
     <air_density>1.2041</air_density>
@@ -1076,11 +1076,11 @@ DO NOT EDIT. This file is generated from an ERB template.
     <a0>0.0</a0>
     <cla>4.752798721</cla>
     <cda>0.6417112299</cda>
-    <cma>-1.8</cma>
+    <cma>0.0</cma>
     <alpha_stall>0.3391428111</alpha_stall>
     <cla_stall>-3.85</cla_stall>
     <cda_stall>-0.9233984055</cda_stall>
-    <cma_stall>0</cma_stall>
+    <cma_stall>0.0</cma_stall>
     <cp>-1.25 0.405 0.1</cp>
     <area>0.0378</area>
     <air_density>1.2041</air_density>
@@ -1094,11 +1094,11 @@ DO NOT EDIT. This file is generated from an ERB template.
     <a0>0.0</a0>
     <cla>4.752798721</cla>
     <cda>0.6417112299</cda>
-    <cma>-1.8</cma>
+    <cma>0.0</cma>
     <alpha_stall>0.3391428111</alpha_stall>
     <cla_stall>-3.85</cla_stall>
     <cda_stall>-0.9233984055</cda_stall>
-    <cma_stall>0</cma_stall>
+    <cma_stall>0.0</cma_stall>
     <cp>-1.25 -0.405 0.1</cp>
     <area>0.0378</area>
     <air_density>1.2041</air_density>

--- a/Gazebo/models/bicopter/model.sdf
+++ b/Gazebo/models/bicopter/model.sdf
@@ -415,7 +415,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -432,7 +432,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -449,7 +449,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -468,7 +468,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -485,7 +485,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -502,7 +502,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>

--- a/Gazebo/models/hexapod_copter/model.sdf
+++ b/Gazebo/models/hexapod_copter/model.sdf
@@ -2423,7 +2423,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.25</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -2440,7 +2440,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.25</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -2459,7 +2459,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.25</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -2476,7 +2476,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.25</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -2495,7 +2495,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.25</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -2512,7 +2512,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.25</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -2531,7 +2531,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.25</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -2548,7 +2548,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.25</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -2567,7 +2567,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.25</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -2584,7 +2584,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.25</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -2603,7 +2603,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.25</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -2620,7 +2620,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.25</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>

--- a/Gazebo/models/skycat_tvbs/model.sdf
+++ b/Gazebo/models/skycat_tvbs/model.sdf
@@ -581,7 +581,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -598,7 +598,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -617,7 +617,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -634,7 +634,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -652,11 +652,11 @@
       <a0>0.13</a0>
       <cla>3.7</cla>
       <cda>0.06417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>0.01 0 0.042</cp>
       <area>0.60</area>
       <air_density>1.2041</air_density>
@@ -670,11 +670,11 @@
       <a0>0.15</a0>
       <cla>6.8</cla>
       <cda>0.06417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.6391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.27 0.322 -0.042</cp>
       <area>0.033</area>
       <air_density>1.2041</air_density>
@@ -690,11 +690,11 @@
       <a0>0.15</a0>
       <cla>6.8</cla>
       <cda>0.06417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.6391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.27 -0.322 -0.042</cp>
       <area>0.033</area>
       <air_density>1.2041</air_density>
@@ -710,11 +710,11 @@
       <a0>0.0</a0>
       <cla>4.752798721</cla>
       <cda>0.6417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.4 0.735 0.08</cp>
       <area>0.12</area>
       <air_density>1.2041</air_density>
@@ -728,11 +728,11 @@
       <a0>0.0</a0>
       <cla>4.752798721</cla>
       <cda>0.6417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.4 -0.735 0.08</cp>
       <area>0.12</area>
       <air_density>1.2041</air_density>

--- a/Gazebo/models/skywalker_x8/model.sdf
+++ b/Gazebo/models/skywalker_x8/model.sdf
@@ -366,7 +366,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -383,7 +383,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -400,11 +400,11 @@
       <a0>0.13</a0>
       <cla>3.7</cla>
       <cda>0.06417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>0.01 0 0</cp>
       <area>0.80</area>
       <air_density>1.2041</air_density>
@@ -418,11 +418,11 @@
       <a0>0.15</a0>
       <cla>6.8</cla>
       <cda>0.06417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.6391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.30 0.75 -0.005</cp>
       <area>0.10</area>
       <air_density>1.2041</air_density>
@@ -438,11 +438,11 @@
       <a0>0.15</a0>
       <cla>6.8</cla>
       <cda>0.06417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.6391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.30 -0.75 -0.005</cp>
       <area>0.10</area>
       <air_density>1.2041</air_density>
@@ -458,11 +458,11 @@
       <a0>0.0</a0>
       <cla>4.752798721</cla>
       <cda>0.6417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.36 1.04 0.08</cp>
       <area>0.12</area>
       <air_density>1.2041</air_density>
@@ -476,11 +476,11 @@
       <a0>0.0</a0>
       <cla>4.752798721</cla>
       <cda>0.6417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.36 -1.04 0.08</cp>
       <area>0.12</area>
       <air_density>1.2041</air_density>
@@ -500,7 +500,7 @@
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.05 0.3 0.05</cp>
       <area>0.50</area>
       <air_density>1.2041</air_density>
@@ -520,7 +520,7 @@
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.05 -0.3 0.05</cp>
       <area>0.50</area>
       <air_density>1.2041</air_density>

--- a/Gazebo/models/skywalker_x8_quad/model.sdf
+++ b/Gazebo/models/skywalker_x8_quad/model.sdf
@@ -717,7 +717,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -734,7 +734,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -752,7 +752,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -769,7 +769,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -787,7 +787,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -804,7 +804,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -822,7 +822,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -839,7 +839,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -857,7 +857,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -874,7 +874,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -891,11 +891,11 @@
       <a0>0.13</a0>
       <cla>3.7</cla>
       <cda>0.06417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>0.01 0 0</cp>
       <area>0.80</area>
       <air_density>1.2041</air_density>
@@ -909,11 +909,11 @@
       <a0>0.15</a0>
       <cla>6.8</cla>
       <cda>0.06417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.6391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.30 0.75 -0.005</cp>
       <area>0.10</area>
       <air_density>1.2041</air_density>
@@ -929,11 +929,11 @@
       <a0>0.15</a0>
       <cla>6.8</cla>
       <cda>0.06417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.6391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.30 -0.75 -0.005</cp>
       <area>0.10</area>
       <air_density>1.2041</air_density>
@@ -949,11 +949,11 @@
       <a0>0.0</a0>
       <cla>4.752798721</cla>
       <cda>0.6417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.36 1.04 0.08</cp>
       <area>0.12</area>
       <air_density>1.2041</air_density>
@@ -967,11 +967,11 @@
       <a0>0.0</a0>
       <cla>4.752798721</cla>
       <cda>0.6417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.36 -1.04 0.08</cp>
       <area>0.12</area>
       <air_density>1.2041</air_density>

--- a/Gazebo/models/swan_k1_hwing/model.sdf
+++ b/Gazebo/models/swan_k1_hwing/model.sdf
@@ -730,7 +730,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -747,7 +747,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -766,7 +766,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -783,7 +783,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -802,7 +802,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -819,7 +819,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -838,7 +838,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -855,7 +855,7 @@
       <alpha_stall>1.4</alpha_stall>
       <cla>4.2500</cla>
       <cda>0.10</cda>
-      <cma>0.00</cma>
+      <cma>0.0</cma>
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
@@ -873,11 +873,11 @@
       <a0>0.13</a0>
       <cla>3.7</cla>
       <cda>0.06417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.025 0 0</cp>
       <area>0.18</area>
       <air_density>1.2041</air_density>
@@ -891,11 +891,11 @@
       <a0>0.0</a0>
       <cla>4.752798721</cla>
       <cda>0.6417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.14 0.59 0.035</cp>
       <area>0.0068</area>
       <air_density>1.2041</air_density>
@@ -909,11 +909,11 @@
       <a0>0.0</a0>
       <cla>4.752798721</cla>
       <cda>0.6417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.14 -0.59 0.035</cp>
       <area>0.0068</area>
       <air_density>1.2041</air_density>
@@ -927,11 +927,11 @@
       <a0>0.0</a0>
       <cla>4.752798721</cla>
       <cda>0.6417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.07 0.25 0</cp>
       <area>0.01</area>
       <air_density>1.2041</air_density>
@@ -945,11 +945,11 @@
       <a0>0.0</a0>
       <cla>4.752798721</cla>
       <cda>0.6417112299</cda>
-      <cma>-1.8</cma>
+      <cma>0.0</cma>
       <alpha_stall>0.3391428111</alpha_stall>
       <cla_stall>-3.85</cla_stall>
       <cda_stall>-0.9233984055</cda_stall>
-      <cma_stall>0</cma_stall>
+      <cma_stall>0.0</cma_stall>
       <cp>-0.07 -0.25 0</cp>
       <area>0.01</area>
       <air_density>1.2041</air_density>


### PR DESCRIPTION
The LiftDrag plugin has changed behaviour in Gazebo Harmonic and the moment coefficient calculation which was previously disabled is now enabled. As we do not have data for this coefficient we set the parameters to zero to ensure consistent behaviour between Gazebo Garden and Gazebo Harmonic.