### PR TITLE
Gazebo: correct Gazebo ENU to ArduPilot NED transform (part 2/2)

### DIFF
--- a/Gazebo/docs/AltiTransition.md
+++ b/Gazebo/docs/AltiTransition.md
@@ -26,7 +26,7 @@ gz sim -v4 -r alti_transition_runway.sdf
 ###  Run ArduPilot SITL
 
 ```bash
-sim_vehicle.py -v ArduPlane -f JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/alti_transition_quad.param --console --map
+sim_vehicle.py -v ArduPlane --model JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/alti_transition_quad.param --console --map
 ```
 
 ### Preflight checks

--- a/Gazebo/docs/BiCopter.md
+++ b/Gazebo/docs/BiCopter.md
@@ -20,13 +20,13 @@ $HOME/SITL_Models/Gazebo/worlds
 #### Run Gazebo
 
 ```bash
-$ gz sim -v4 -r bicopter_runway.sdf
+gz sim -v4 -r bicopter_runway.sdf
 ```
 
 #### Run ArduPilot SITL
 
 ```bash
-$ sim_vehicle.py -v ArduCopter --model JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/bicopter.param --console --map
+sim_vehicle.py -v ArduCopter --model JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/bicopter.param --console --map
 ```
 
 ### Notes

--- a/Gazebo/docs/BlueBoat.md
+++ b/Gazebo/docs/BlueBoat.md
@@ -39,7 +39,7 @@ gz sim -v4 -r waves.sdf
 #### Run ArduPilot SITL
 
 ```bash
-sim_vehicle.py -D -v Rover -f rover-skid --model JSON  --console --map
+sim_vehicle.py -v Rover -f rover-skid --model JSON  --console --map --custom-location='51.566151,-4.034345,10.0,-135'
 ```
 
 The default skid steer rover parameters give a workable simulation with minor modifications:

--- a/Gazebo/docs/Catamaran.md
+++ b/Gazebo/docs/Catamaran.md
@@ -33,7 +33,7 @@ gz sim -v4 -r catamaran_waves.sdf
 #### Run ArduPilot SITL
 
 ```bash
-sim_vehicle.py -D -v Rover --model JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/catamaran.param --console --map --custom-location='51.566151,-4.034345,10.0,-135'
+sim_vehicle.py -v Rover --model JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/catamaran.param --console --map --custom-location='51.566151,-4.034345,10.0,-135'
 ```
  
 #### Wave and wind settings

--- a/Gazebo/docs/DAF_XF_450_Tractor.md
+++ b/Gazebo/docs/DAF_XF_450_Tractor.md
@@ -11,14 +11,14 @@ The vehicle is configured to have car steering (i.e. different wheel angles for 
 **Run Gazebo**
 
 ```bash
-$ gz sim -v4 -s -r daf_truck_runway.sdf
+gz sim -v4 -r daf_truck_runway.sdf
 ```
 **Run ArduPilot SITL**
 
 Copy the script `daf_xf_450_tractor_mixer.lua` to the SITL scripts directory, then start SITL:
 
 ```bash
-sim_vehicle.py -v Rover -f JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/daf_xf_450_tractor.param --console --map
+sim_vehicle.py -v Rover --model JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/daf_xf_450_tractor.param --console --map
 ```
 
 You may need to reboot the autopilot to ensure the additional scripting parameters are loaded.

--- a/Gazebo/docs/HexapodCopter.md
+++ b/Gazebo/docs/HexapodCopter.md
@@ -33,7 +33,7 @@ $HOME/SITL_Models/Gazebo/worlds
 #### Run Gazebo
 
 ```bash
-$ gz sim -v4 -r hexapod_copter_runway.sdf
+gz sim -v4 -r hexapod_copter_runway.sdf
 ```
 
 #### Run ArduPilot SITL
@@ -42,7 +42,7 @@ Copy the script $HOME/SITL_Models/Gazebo/scripts/hexapod_copter.lua to the SITL 
 then start SITL:
 
 ```bash
-sim_vehicle.py -D -v ArduCopter -f hexa --model JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/hexapod_copter.param --console
+sim_vehicle.py -v ArduCopter -f hexa --model JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/hexapod_copter.param --console --map
 ```
 
 ## Dimensions

--- a/Gazebo/docs/Quadruped.md
+++ b/Gazebo/docs/Quadruped.md
@@ -19,7 +19,7 @@ $HOME/SITL_Models/Gazebo/worlds
 #### Run Gazebo
 
 ```bash
-$ gz sim -v4 -r quadruped_runway.sdf
+gz sim -v4 -r quadruped_runway.sdf
 ```
 
 #### Run ArduPilot SITL
@@ -33,7 +33,7 @@ Copy the Lua script `quadruped.lua` to the `scripts` folder for SITL (this is us
 The parameters set `SCR_ENABLE = 1` and you will need to reboot the autopilot after the initial start to retrieve the full set of scripting parameters. You may also need to increase the `SCR_HEAP_SIZE`.
 
 ```bash
-$ sim_vehicle.py -v Rover -f JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/quadruped.param --console --map
+sim_vehicle.py -v Rover --model JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/quadruped.param --console --map
 ```
 
 #### Controls

--- a/Gazebo/docs/RoverPlayPen.md
+++ b/Gazebo/docs/RoverPlayPen.md
@@ -24,7 +24,7 @@ The model may be included in a world sdf file using the `<include>` element:
 An example world containing a wild thumper rover is provided as an example:
 
 ```bash
-$ gz sim -r wildthumper_playpen.sdf
+gz sim -v4 -r wildthumper_playpen.sdf
 ```
 
 For details on controlling the wild thumper rover with SITL see: [Wild Thumper 6WD](./WildThumper.md).

--- a/Gazebo/docs/Sawppy.md
+++ b/Gazebo/docs/Sawppy.md
@@ -33,7 +33,7 @@ gz sim -v4 sawppy_playpen.sdf
 ### Start SITL
 
 ```bash
-sim_vehicle.py -v Rover -f JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/sawppy.param --console
+sim_vehicle.py -v Rover --model JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/sawppy.param --console --map
 ```
 
 ### Configure parameters

--- a/Gazebo/docs/SkyCatTVBS.md
+++ b/Gazebo/docs/SkyCatTVBS.md
@@ -19,13 +19,13 @@ $HOME/SITL_Models/Gazebo/worlds
 #### Run Gazebo
 
 ```bash
-$ gz sim -v4 -r skycat_runway.sdf
+gz sim -v4 -r skycat_runway.sdf
 ```
 
 #### Run ArduPilot SITL
 
 ```bash
-$ sim_vehicle.py -v ArduPlane -f JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/skycat_tvbs.param --console --map
+sim_vehicle.py -v ArduPlane --model JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/skycat_tvbs.param --console --map
 ```
 
 ### Testing

--- a/Gazebo/docs/SkywalkerX8.md
+++ b/Gazebo/docs/SkywalkerX8.md
@@ -23,13 +23,13 @@ An X8 configured as a delta-wing plane.
 #### Run Gazebo
 
 ```bash
-$ gz sim -v4 -r skywalker_x8_runway.sdf
+gz sim -v4 -r skywalker_x8_runway.sdf
 ```
 
 #### Run ArduPilot SITL
 
 ```bash
-$ sim_vehicle.py -v ArduPlane -f JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/skywalker_x8.param --console --map
+sim_vehicle.py -v ArduPlane --model JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/skywalker_x8.param --console --map
 ```
 
 ### `skywalker_x8_quad`
@@ -39,13 +39,13 @@ An X8 configured as a delta-wing quad plane.
 #### Run Gazebo
 
 ```bash
-$ gz sim -v4 -r skywalker_x8_quad_runway.sdf
+gz sim -v4 -r skywalker_x8_quad_runway.sdf
 ```
 
 #### Run ArduPilot SITL
 
 ```bash
-$ sim_vehicle.py -v ArduPlane -f JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/skywalker_x8_quad.param --console --map
+sim_vehicle.py -v ArduPlane --model JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/skywalker_x8_quad.param --console --map
 ```
 
 ### Notes

--- a/Gazebo/docs/Swan-K1.md
+++ b/Gazebo/docs/Swan-K1.md
@@ -22,11 +22,11 @@ $HOME/SITL_Models/Gazebo/worlds
 #### Run Gazebo
 
 ```bash
-$ gz sim -v4 -r swan_k1_hwing_runway.sdf
+gz sim -v4 -r swan_k1_hwing_runway.sdf
 ```
 
 #### Run ArduPilot SITL
 
 ```bash
-$ sim_vehicle.py -v ArduPlane -f JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/swan_k1_hwing.param --console --map
+sim_vehicle.py -v ArduPlane --model JSON --add-param-file=$HOME/SITL_Models/Gazebo/config/swan_k1_hwing.param --console --map
 ```

--- a/Gazebo/docs/WildThumper.md
+++ b/Gazebo/docs/WildThumper.md
@@ -23,7 +23,7 @@ A Wild Thumper 6WD skid-steer rover.
 #### Run Gazebo
 
 ```bash
-$ gz sim -v4 -r wildthumper_runway.sdf
+gz sim -v4 -r wildthumper_runway.sdf
 ```
 
 #### Run ArduPilot SITL
@@ -31,7 +31,7 @@ $ gz sim -v4 -r wildthumper_runway.sdf
 The model can be run with the default `rover-skid` SITL parameters.
 
 ```bash
-$ sim_vehicle.py -v Rover -f rover-skid --model JSON  --console --map
+sim_vehicle.py -v Rover -f rover-skid --model JSON  --console --map
 ```
 
 ## Credits

--- a/Gazebo/models/alti_transition_quad/model.sdf
+++ b/Gazebo/models/alti_transition_quad/model.sdf
@@ -739,11 +739,11 @@
     </joint>
 
     <!-- plugins -->
-    <plugin filename="libgz-sim-joint-state-publisher-system.so"
+    <plugin filename="gz-sim-joint-state-publisher-system"
       name="gz::sim::systems::JointStatePublisher">
     </plugin>
     <!-- motor_1 (cw) lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -760,7 +760,7 @@
       <upward>0 0 1</upward>
       <link_name>motor_1</link_name>
     </plugin>
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -778,7 +778,7 @@
       <link_name>motor_1</link_name>
     </plugin>
     <!-- motor_2 (cw) lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -795,7 +795,7 @@
       <upward>0 0 1</upward>
       <link_name>motor_2</link_name>
     </plugin>
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -813,7 +813,7 @@
       <link_name>motor_2</link_name>
     </plugin>
     <!-- motor_3 (ccw) lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -830,7 +830,7 @@
       <upward>0 0 1</upward>
       <link_name>motor_3</link_name>
     </plugin>
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -848,7 +848,7 @@
       <link_name>motor_3</link_name>
     </plugin>
     <!-- motor_4 (ccw) lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -865,7 +865,7 @@
       <upward>0 0 1</upward>
       <link_name>motor_4</link_name>
     </plugin>
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -883,7 +883,7 @@
       <link_name>motor_4</link_name>
     </plugin>
     <!-- motor_f (ccw) lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.30</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -900,7 +900,7 @@
       <upward>0 0 1</upward>
       <link_name>motor_f</link_name>
     </plugin>
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.30</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -918,7 +918,7 @@
       <link_name>motor_f</link_name>
     </plugin>
     <!-- main_wing lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.13</a0>
       <cla>3.7</cla>
@@ -936,7 +936,7 @@
       <link_name>base_link</link_name>
     </plugin>
     <!-- left_aileron lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.15</a0>
       <cla>6.8</cla>
@@ -956,7 +956,7 @@
       <control_joint_rad_to_cl>-5.0</control_joint_rad_to_cl>
     </plugin>
     <!-- right_aileron lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.15</a0>
       <cla>6.8</cla>
@@ -976,7 +976,7 @@
       <control_joint_rad_to_cl>-5.0</control_joint_rad_to_cl>
     </plugin>
     <!-- left_winglet lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.0</a0>
       <cla>4.752798721</cla>
@@ -994,7 +994,7 @@
       <link_name>base_link</link_name>
     </plugin>
     <!-- right_winglet lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.0</a0>
       <cla>4.752798721</cla>
@@ -1012,7 +1012,7 @@
       <link_name>base_link</link_name>
     </plugin>
     <!-- hstab lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.13</a0>
       <cla>3.7</cla>
@@ -1030,7 +1030,7 @@
       <link_name>base_link</link_name>
     </plugin>
     <!-- elevator lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.15</a0>
       <cla>6.8</cla>
@@ -1050,7 +1050,7 @@
       <control_joint_rad_to_cl>-5.0</control_joint_rad_to_cl>
     </plugin>
     <!-- left_vstab lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.0</a0>
       <cla>4.752798721</cla>
@@ -1068,7 +1068,7 @@
       <link_name>base_link</link_name>
     </plugin>
     <!-- right_vstab lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.0</a0>
       <cla>4.752798721</cla>
@@ -1086,36 +1086,36 @@
       <link_name>base_link</link_name>
     </plugin>
 
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>motor_1_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>motor_2_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>motor_3_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>motor_4_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>motor_f_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>left_aileron_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>right_aileron_joint</joint_name>
     </plugin>
 
-    <plugin name="ArduPilotPlugin" filename="libArduPilotPlugin.so">
+    <plugin name="ArduPilotPlugin" filename="ArduPilotPlugin">
       <!-- Port settings -->
       <fdm_addr>127.0.0.1</fdm_addr>
       <fdm_port_in>9002</fdm_port_in>

--- a/Gazebo/models/alti_transition_quad/model.sdf
+++ b/Gazebo/models/alti_transition_quad/model.sdf
@@ -715,7 +715,7 @@
         </inertia>
       </inertial>
       <sensor name="imu_sensor" type="imu">
-        <pose>0 0 0 3.141593 0 0</pose>
+        <pose degrees="true">0 0 0 180 0 0</pose>
         <always_on>1</always_on>
         <update_rate>1000.0</update_rate>
       </sensor>

--- a/Gazebo/models/alti_transition_quad/model.sdf.erb
+++ b/Gazebo/models/alti_transition_quad/model.sdf.erb
@@ -736,7 +736,7 @@ DO NOT EDIT. This file is generated from an ERB template.
       </inertia>
     </inertial>
     <sensor name="imu_sensor" type="imu">
-      <pose>0 0 0 3.141593 0 0</pose>
+      <pose degrees="true">0 0 0 180 0 0</pose>
       <always_on>1</always_on>
       <update_rate>1000.0</update_rate>
     </sensor>

--- a/Gazebo/models/alti_transition_quad/model.sdf.erb
+++ b/Gazebo/models/alti_transition_quad/model.sdf.erb
@@ -760,11 +760,11 @@ DO NOT EDIT. This file is generated from an ERB template.
   </joint>
 
   <!-- plugins -->
-  <plugin filename="libgz-sim-joint-state-publisher-system.so"
+  <plugin filename="gz-sim-joint-state-publisher-system"
     name="gz::sim::systems::JointStatePublisher">
   </plugin>
   <!-- motor_1 (cw) lift-drag -->
-  <plugin filename="libgz-sim-lift-drag-system.so"
+  <plugin filename="gz-sim-lift-drag-system"
       name="gz::sim::systems::LiftDrag">
     <a0>0.3</a0>
     <alpha_stall>1.4</alpha_stall>
@@ -781,7 +781,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <upward>0 0 1</upward>
     <link_name>motor_1</link_name>
   </plugin>
-  <plugin filename="libgz-sim-lift-drag-system.so"
+  <plugin filename="gz-sim-lift-drag-system"
       name="gz::sim::systems::LiftDrag">
     <a0>0.3</a0>
     <alpha_stall>1.4</alpha_stall>
@@ -799,7 +799,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <link_name>motor_1</link_name>
   </plugin>
   <!-- motor_2 (cw) lift-drag -->
-  <plugin filename="libgz-sim-lift-drag-system.so"
+  <plugin filename="gz-sim-lift-drag-system"
       name="gz::sim::systems::LiftDrag">
     <a0>0.3</a0>
     <alpha_stall>1.4</alpha_stall>
@@ -816,7 +816,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <upward>0 0 1</upward>
     <link_name>motor_2</link_name>
   </plugin>
-  <plugin filename="libgz-sim-lift-drag-system.so"
+  <plugin filename="gz-sim-lift-drag-system"
       name="gz::sim::systems::LiftDrag">
     <a0>0.3</a0>
     <alpha_stall>1.4</alpha_stall>
@@ -834,7 +834,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <link_name>motor_2</link_name>
   </plugin>
   <!-- motor_3 (ccw) lift-drag -->
-  <plugin filename="libgz-sim-lift-drag-system.so"
+  <plugin filename="gz-sim-lift-drag-system"
       name="gz::sim::systems::LiftDrag">
     <a0>0.3</a0>
     <alpha_stall>1.4</alpha_stall>
@@ -851,7 +851,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <upward>0 0 1</upward>
     <link_name>motor_3</link_name>
   </plugin>
-  <plugin filename="libgz-sim-lift-drag-system.so"
+  <plugin filename="gz-sim-lift-drag-system"
       name="gz::sim::systems::LiftDrag">
     <a0>0.3</a0>
     <alpha_stall>1.4</alpha_stall>
@@ -869,7 +869,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <link_name>motor_3</link_name>
   </plugin>
   <!-- motor_4 (ccw) lift-drag -->
-  <plugin filename="libgz-sim-lift-drag-system.so"
+  <plugin filename="gz-sim-lift-drag-system"
       name="gz::sim::systems::LiftDrag">
     <a0>0.3</a0>
     <alpha_stall>1.4</alpha_stall>
@@ -886,7 +886,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <upward>0 0 1</upward>
     <link_name>motor_4</link_name>
   </plugin>
-  <plugin filename="libgz-sim-lift-drag-system.so"
+  <plugin filename="gz-sim-lift-drag-system"
       name="gz::sim::systems::LiftDrag">
     <a0>0.3</a0>
     <alpha_stall>1.4</alpha_stall>
@@ -904,7 +904,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <link_name>motor_4</link_name>
   </plugin>
   <!-- motor_f (ccw) lift-drag -->
-  <plugin filename="libgz-sim-lift-drag-system.so"
+  <plugin filename="gz-sim-lift-drag-system"
       name="gz::sim::systems::LiftDrag">
     <a0>0.30</a0>
     <alpha_stall>1.4</alpha_stall>
@@ -921,7 +921,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <upward>0 0 1</upward>
     <link_name>motor_f</link_name>
   </plugin>
-  <plugin filename="libgz-sim-lift-drag-system.so"
+  <plugin filename="gz-sim-lift-drag-system"
       name="gz::sim::systems::LiftDrag">
     <a0>0.30</a0>
     <alpha_stall>1.4</alpha_stall>
@@ -939,7 +939,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <link_name>motor_f</link_name>
   </plugin>
   <!-- main_wing lift-drag -->
-  <plugin filename="libgz-sim-lift-drag-system.so"
+  <plugin filename="gz-sim-lift-drag-system"
       name="gz::sim::systems::LiftDrag">
     <a0>0.13</a0>
     <cla>3.7</cla>
@@ -957,7 +957,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <link_name>base_link</link_name>
   </plugin>
   <!-- left_aileron lift-drag -->
-  <plugin filename="libgz-sim-lift-drag-system.so"
+  <plugin filename="gz-sim-lift-drag-system"
       name="gz::sim::systems::LiftDrag">
     <a0>0.15</a0>
     <cla>6.8</cla>
@@ -977,7 +977,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <control_joint_rad_to_cl>-5.0</control_joint_rad_to_cl>
   </plugin>
   <!-- right_aileron lift-drag -->
-  <plugin filename="libgz-sim-lift-drag-system.so"
+  <plugin filename="gz-sim-lift-drag-system"
       name="gz::sim::systems::LiftDrag">
     <a0>0.15</a0>
     <cla>6.8</cla>
@@ -997,7 +997,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <control_joint_rad_to_cl>-5.0</control_joint_rad_to_cl>
   </plugin>
   <!-- left_winglet lift-drag -->
-  <plugin filename="libgz-sim-lift-drag-system.so"
+  <plugin filename="gz-sim-lift-drag-system"
       name="gz::sim::systems::LiftDrag">
     <a0>0.0</a0>
     <cla>4.752798721</cla>
@@ -1015,7 +1015,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <link_name>base_link</link_name>
   </plugin>
   <!-- right_winglet lift-drag -->
-  <plugin filename="libgz-sim-lift-drag-system.so"
+  <plugin filename="gz-sim-lift-drag-system"
       name="gz::sim::systems::LiftDrag">
     <a0>0.0</a0>
     <cla>4.752798721</cla>
@@ -1033,7 +1033,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <link_name>base_link</link_name>
   </plugin>
   <!-- hstab lift-drag -->
-  <plugin filename="libgz-sim-lift-drag-system.so"
+  <plugin filename="gz-sim-lift-drag-system"
       name="gz::sim::systems::LiftDrag">
     <a0>0.13</a0>
     <cla>3.7</cla>
@@ -1051,7 +1051,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <link_name>base_link</link_name>
   </plugin>
   <!-- elevator lift-drag -->
-  <plugin filename="libgz-sim-lift-drag-system.so"
+  <plugin filename="gz-sim-lift-drag-system"
       name="gz::sim::systems::LiftDrag">
     <a0>0.15</a0>
     <cla>6.8</cla>
@@ -1071,7 +1071,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <control_joint_rad_to_cl>-5.0</control_joint_rad_to_cl>
   </plugin>
   <!-- left_vstab lift-drag -->
-  <plugin filename="libgz-sim-lift-drag-system.so"
+  <plugin filename="gz-sim-lift-drag-system"
       name="gz::sim::systems::LiftDrag">
     <a0>0.0</a0>
     <cla>4.752798721</cla>
@@ -1089,7 +1089,7 @@ DO NOT EDIT. This file is generated from an ERB template.
     <link_name>base_link</link_name>
   </plugin>
   <!-- right_vstab lift-drag -->
-  <plugin filename="libgz-sim-lift-drag-system.so"
+  <plugin filename="gz-sim-lift-drag-system"
       name="gz::sim::systems::LiftDrag">
     <a0>0.0</a0>
     <cla>4.752798721</cla>
@@ -1107,36 +1107,36 @@ DO NOT EDIT. This file is generated from an ERB template.
     <link_name>base_link</link_name>
   </plugin>
 
-  <plugin filename="libgz-sim-apply-joint-force-system.so"
+  <plugin filename="gz-sim-apply-joint-force-system"
     name="gz::sim::systems::ApplyJointForce">
     <joint_name>motor_1_joint</joint_name>
   </plugin>
-  <plugin filename="libgz-sim-apply-joint-force-system.so"
+  <plugin filename="gz-sim-apply-joint-force-system"
     name="gz::sim::systems::ApplyJointForce">
     <joint_name>motor_2_joint</joint_name>
   </plugin>
-  <plugin filename="libgz-sim-apply-joint-force-system.so"
+  <plugin filename="gz-sim-apply-joint-force-system"
     name="gz::sim::systems::ApplyJointForce">
     <joint_name>motor_3_joint</joint_name>
   </plugin>
-  <plugin filename="libgz-sim-apply-joint-force-system.so"
+  <plugin filename="gz-sim-apply-joint-force-system"
     name="gz::sim::systems::ApplyJointForce">
     <joint_name>motor_4_joint</joint_name>
   </plugin>
-  <plugin filename="libgz-sim-apply-joint-force-system.so"
+  <plugin filename="gz-sim-apply-joint-force-system"
     name="gz::sim::systems::ApplyJointForce">
     <joint_name>motor_f_joint</joint_name>
   </plugin>
-  <plugin filename="libgz-sim-apply-joint-force-system.so"
+  <plugin filename="gz-sim-apply-joint-force-system"
     name="gz::sim::systems::ApplyJointForce">
     <joint_name>left_aileron_joint</joint_name>
   </plugin>
-  <plugin filename="libgz-sim-apply-joint-force-system.so"
+  <plugin filename="gz-sim-apply-joint-force-system"
     name="gz::sim::systems::ApplyJointForce">
     <joint_name>right_aileron_joint</joint_name>
   </plugin>
 
-  <plugin name="ArduPilotPlugin" filename="libArduPilotPlugin.so">
+  <plugin name="ArduPilotPlugin" filename="ArduPilotPlugin">
     <!-- Port settings -->
     <fdm_addr><%= fdm_addr %></fdm_addr>
     <fdm_port_in><%= fdm_port_in %></fdm_port_in>

--- a/Gazebo/models/daf_xf_450_flatbed_trailer/model.sdf
+++ b/Gazebo/models/daf_xf_450_flatbed_trailer/model.sdf
@@ -594,11 +594,11 @@
 
   <!-- Plugins -->
   <plugin name="gz::sim::systems::JointStatePublisher"
-      filename="libgz-sim-joint-state-publisher-system.so">
+      filename="gz-sim-joint-state-publisher-system">
   </plugin>
 
   <plugin name="ArduPilotPlugin"
-      filename="libArduPilotPlugin.so">
+      filename="ArduPilotPlugin">
     <fdm_addr>127.0.0.1</fdm_addr>
     <fdm_port_in>9012</fdm_port_in>
     <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>

--- a/Gazebo/models/daf_xf_450_flatbed_trailer/model.sdf
+++ b/Gazebo/models/daf_xf_450_flatbed_trailer/model.sdf
@@ -571,7 +571,7 @@
       </inertia>
     </inertial>
     <sensor name="imu_sensor" type="imu">
-      <pose>0 0 0 3.141593 0 0</pose>
+      <pose degrees="true">0 0 0 180 0 0</pose>
       <always_on>1</always_on>
       <update_rate>1000.0</update_rate>
     </sensor>

--- a/Gazebo/models/daf_xf_450_flatbed_trailer/model.sdf.erb
+++ b/Gazebo/models/daf_xf_450_flatbed_trailer/model.sdf.erb
@@ -617,11 +617,11 @@ DO NOT EDIT. This file is generated from an ERB template.
 
   <!-- Plugins -->
   <plugin name="gz::sim::systems::JointStatePublisher"
-      filename="libgz-sim-joint-state-publisher-system.so">
+      filename="gz-sim-joint-state-publisher-system">
   </plugin>
 
   <plugin name="ArduPilotPlugin"
-      filename="libArduPilotPlugin.so">
+      filename="ArduPilotPlugin">
     <fdm_addr><%= fdm_addr %></fdm_addr>
     <fdm_port_in><%= fdm_port_in %></fdm_port_in>
     <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>

--- a/Gazebo/models/daf_xf_450_flatbed_trailer/model.sdf.erb
+++ b/Gazebo/models/daf_xf_450_flatbed_trailer/model.sdf.erb
@@ -594,7 +594,7 @@ DO NOT EDIT. This file is generated from an ERB template.
       </inertia>
     </inertial>
     <sensor name="imu_sensor" type="imu">
-      <pose>0 0 0 3.141593 0 0</pose>
+      <pose degrees="true">0 0 0 180 0 0</pose>
       <always_on>1</always_on>
       <update_rate>1000.0</update_rate>
     </sensor>

--- a/Gazebo/models/daf_xf_450_tractor/model.sdf
+++ b/Gazebo/models/daf_xf_450_tractor/model.sdf
@@ -667,27 +667,27 @@
 
   <!-- Plugins -->
   <plugin name="gz::sim::systems::JointStatePublisher"
-      filename="libgz-sim-joint-state-publisher-system.so">
+      filename="gz-sim-joint-state-publisher-system">
   </plugin>
   <plugin name="gz::sim::systems::ApplyJointForce"
-      filename="libgz-sim-apply-joint-force-system.so">
+      filename="gz-sim-apply-joint-force-system">
       <joint_name>rear_left_wheel_joint</joint_name>
   </plugin>
   <plugin name="gz::sim::systems::ApplyJointForce"
-      filename="libgz-sim-apply-joint-force-system.so">
+      filename="gz-sim-apply-joint-force-system">
       <joint_name>rear_right_wheel_joint</joint_name>
   </plugin>
   <plugin name="gz::sim::systems::ApplyJointForce"
-      filename="libgz-sim-apply-joint-force-system.so">
+      filename="gz-sim-apply-joint-force-system">
       <joint_name>front_left_steer_joint</joint_name>
   </plugin>
   <plugin name="gz::sim::systems::ApplyJointForce"
-      filename="libgz-sim-apply-joint-force-system.so">
+      filename="gz-sim-apply-joint-force-system">
       <joint_name>front_right_steer_joint</joint_name>
   </plugin>
 
   <plugin name="ArduPilotPlugin"
-      filename="libArduPilotPlugin.so">
+      filename="ArduPilotPlugin">
     <!-- Port settings -->
     <fdm_addr>127.0.0.1</fdm_addr>
     <fdm_port_in>9002</fdm_port_in>

--- a/Gazebo/models/daf_xf_450_tractor/model.sdf
+++ b/Gazebo/models/daf_xf_450_tractor/model.sdf
@@ -644,7 +644,7 @@
       </inertia>
     </inertial>
     <sensor name="imu_sensor" type="imu">
-      <pose>0 0 0 3.141593 0 0</pose>
+      <pose degrees="true">0 0 0 180 0 0</pose>
       <always_on>1</always_on>
       <update_rate>1000.0</update_rate>
     </sensor>

--- a/Gazebo/models/daf_xf_450_tractor/model.sdf.erb
+++ b/Gazebo/models/daf_xf_450_tractor/model.sdf.erb
@@ -697,27 +697,27 @@ DO NOT EDIT. This file is generated from an ERB template.
 
   <!-- Plugins -->
   <plugin name="gz::sim::systems::JointStatePublisher"
-      filename="libgz-sim-joint-state-publisher-system.so">
+      filename="gz-sim-joint-state-publisher-system">
   </plugin>
   <plugin name="gz::sim::systems::ApplyJointForce"
-      filename="libgz-sim-apply-joint-force-system.so">
+      filename="gz-sim-apply-joint-force-system">
       <joint_name>rear_left_wheel_joint</joint_name>
   </plugin>
   <plugin name="gz::sim::systems::ApplyJointForce"
-      filename="libgz-sim-apply-joint-force-system.so">
+      filename="gz-sim-apply-joint-force-system">
       <joint_name>rear_right_wheel_joint</joint_name>
   </plugin>
   <plugin name="gz::sim::systems::ApplyJointForce"
-      filename="libgz-sim-apply-joint-force-system.so">
+      filename="gz-sim-apply-joint-force-system">
       <joint_name>front_left_steer_joint</joint_name>
   </plugin>
   <plugin name="gz::sim::systems::ApplyJointForce"
-      filename="libgz-sim-apply-joint-force-system.so">
+      filename="gz-sim-apply-joint-force-system">
       <joint_name>front_right_steer_joint</joint_name>
   </plugin>
 
   <plugin name="ArduPilotPlugin"
-      filename="libArduPilotPlugin.so">
+      filename="ArduPilotPlugin">
     <!-- Port settings -->
     <fdm_addr><%= fdm_addr %></fdm_addr>
     <fdm_port_in><%= fdm_port_in %></fdm_port_in>

--- a/Gazebo/models/hexapod_copter/model.sdf
+++ b/Gazebo/models/hexapod_copter/model.sdf
@@ -2176,7 +2176,7 @@
     </joint>
 
     <!-- plugins -->
-    <plugin filename="libgz-sim-joint-state-publisher-system.so"
+    <plugin filename="gz-sim-joint-state-publisher-system"
       name="gz::sim::systems::JointStatePublisher">
     </plugin>
 

--- a/Gazebo/models/quadruped/model.sdf
+++ b/Gazebo/models/quadruped/model.sdf
@@ -1275,59 +1275,59 @@
     </joint>
 
     <!-- plugins -->
-    <plugin filename="libgz-sim-joint-state-publisher-system.so"
+    <plugin filename="gz-sim-joint-state-publisher-system"
       name="gz::sim::systems::JointStatePublisher">
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>coxa_bl_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>femur_bl_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>tibia_bl_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>coxa_br_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>femur_br_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>tibia_br_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>coxa_fl_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>femur_fl_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>tibia_fl_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>coxa_fr_link</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>femur_fr_link</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>tibia_fr_link</joint_name>
     </plugin>
 
-    <plugin name="ArduPilotPlugin" filename="libArduPilotPlugin.so">
+    <plugin name="ArduPilotPlugin" filename="ArduPilotPlugin">
       <!-- Port settings -->
       <fdm_addr>127.0.0.1</fdm_addr>
       <fdm_port_in>9002</fdm_port_in>

--- a/Gazebo/models/quadruped/model.sdf
+++ b/Gazebo/models/quadruped/model.sdf
@@ -14,7 +14,7 @@
         </inertia>
       </inertial>
       <collision name='base_link_collision'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.177 0.101 0.053</size>
@@ -37,7 +37,7 @@
         </surface>
       </collision>
       <visual name='base_link_visual'>
-        <pose>0 0 -0.0265 0 -0 0</pose>
+        <pose>0 0 -0.0265 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -90,9 +90,9 @@
       </physics>
     </joint>
     <link name='coxa_bl_link'>
-      <pose relative_to='coxa_bl_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='coxa_bl_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0.01425 0 0 0 1.5708 0</pose>
+        <pose degrees="true">0.01425 0 0 0 90 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>9.26875e-06</ixx>
@@ -104,7 +104,7 @@
         </inertia>
       </inertial>
       <collision name='coxa_bl_link_collision'>
-        <pose>0.01425 0 0 0 1.5708 0</pose>
+        <pose degrees="true">0.01425 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.0285</length>
@@ -125,7 +125,7 @@
         </surface>
       </collision>
       <visual name='coxa_bl_link_visual'>
-        <pose>0 0 0.0196 0 -0 0</pose>
+        <pose>0 0 0.0196 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -180,7 +180,7 @@
     <link name='femur_bl_link'>
       <pose relative_to='femur_bl_joint'>0 0 0 0 -0 0</pose>
       <inertial>
-        <pose>0.0381 0 0 0 1.5708 0</pose>
+        <pose degrees="true">0.0381 0 0 0 90 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>5.0887e-05</ixx>
@@ -192,7 +192,7 @@
         </inertia>
       </inertial>
       <collision name='femur_bl_link_collision'>
-        <pose>0.0381 0 0 0 1.5708 0</pose>
+        <pose degrees="true">0.0381 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.0762</length>
@@ -213,7 +213,7 @@
         </surface>
       </collision>
       <visual name='femur_bl_link_visual'>
-        <pose>0 -0.026 0 0 -0 0</pose>
+        <pose>0 -0.026 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -268,7 +268,7 @@
     <link name='tibia_bl_link'>
       <pose relative_to='tibia_bl_joint'>0 0 0 0 -0 0</pose>
       <inertial>
-        <pose>0 0 -0.051 0 -0 0</pose>
+        <pose>0 0 -0.051 0 0 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>8.92e-05</ixx>
@@ -280,7 +280,7 @@
         </inertia>
       </inertial>
       <collision name='tibia_bl_link_collision'>
-        <pose>0 0 -0.051 0 -0 0</pose>
+        <pose>0 0 -0.051 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.102</length>
@@ -301,7 +301,7 @@
         </surface>
       </collision>
       <collision name='tibia_bl_link_fixed_joint_lump__foot_bl_link_collision_1'>
-        <pose>0 0 -0.102 0 -0 0</pose>
+        <pose>0 0 -0.102 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -329,7 +329,7 @@
         </surface>
       </collision>
       <visual name='tibia_bl_link_visual'>
-        <pose>0 -0.0185 0 0 -0 0</pose>
+        <pose>0 -0.0185 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -383,9 +383,9 @@
       </physics>
     </joint>
     <link name='coxa_br_link'>
-      <pose relative_to='coxa_br_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='coxa_br_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0.01425 0 0 0 1.5708 0</pose>
+        <pose degrees="true">0.01425 0 0 0 90 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>9.26875e-06</ixx>
@@ -397,7 +397,7 @@
         </inertia>
       </inertial>
       <collision name='coxa_br_link_collision'>
-        <pose>0.01425 0 0 0 1.5708 0</pose>
+        <pose degrees="true">0.01425 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.0285</length>
@@ -418,7 +418,7 @@
         </surface>
       </collision>
       <visual name='coxa_br_link_visual'>
-        <pose>0 0 0.0196 0 -0 0</pose>
+        <pose>0 0 0.0196 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -445,7 +445,7 @@
       <velocity_decay/>
     </link>
     <joint name='femur_br_joint' type='revolute'>
-      <pose relative_to='coxa_br_link'>0.0285 0 0 0 -0 0</pose>
+      <pose relative_to='coxa_br_link'>0.0285 0 0 0 0 0</pose>
       <parent>coxa_br_link</parent>
       <child>femur_br_link</child>
       <axis>
@@ -471,9 +471,9 @@
       </physics>
     </joint>
     <link name='femur_br_link'>
-      <pose relative_to='femur_br_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='femur_br_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0.0381 0 0 0 1.5708 0</pose>
+        <pose degrees="true">0.0381 0 0 0 90 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>5.0887e-05</ixx>
@@ -485,7 +485,7 @@
         </inertia>
       </inertial>
       <collision name='femur_br_link_collision'>
-        <pose>0.0381 0 0 0 1.5708 0</pose>
+        <pose degrees="true">0.0381 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.0762</length>
@@ -506,7 +506,7 @@
         </surface>
       </collision>
       <visual name='femur_br_link_visual'>
-        <pose>0 0.026 0 0 -0 0</pose>
+        <pose>0 0.026 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -533,7 +533,7 @@
       <velocity_decay/>
     </link>
     <joint name='tibia_br_joint' type='revolute'>
-      <pose relative_to='femur_br_link'>0.0762 0 0 0 -0 0</pose>
+      <pose relative_to='femur_br_link'>0.0762 0 0 0 0 0</pose>
       <parent>femur_br_link</parent>
       <child>tibia_br_link</child>
       <axis>
@@ -559,9 +559,9 @@
       </physics>
     </joint>
     <link name='tibia_br_link'>
-      <pose relative_to='tibia_br_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='tibia_br_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 -0.051 0 -0 0</pose>
+        <pose>0 0 -0.051 0 0 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>8.92e-05</ixx>
@@ -573,7 +573,7 @@
         </inertia>
       </inertial>
       <collision name='tibia_br_link_collision'>
-        <pose>0 0 -0.051 0 -0 0</pose>
+        <pose>0 0 -0.051 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.102</length>
@@ -594,7 +594,7 @@
         </surface>
       </collision>
       <collision name='tibia_br_link_fixed_joint_lump__foot_br_link_collision_1'>
-        <pose>0 0 -0.102 0 -0 0</pose>
+        <pose>0 0 -0.102 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -622,7 +622,7 @@
         </surface>
       </collision>
       <visual name='tibia_br_link_visual'>
-        <pose>0 0.0185 0 0 -0 0</pose>
+        <pose>0 0.0185 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -650,7 +650,7 @@
       <velocity_decay/>
     </link>
     <joint name='coxa_fl_joint' type='revolute'>
-      <pose relative_to='base_link'>0.0885 0.0505 0 0 -0 0.785398</pose>
+      <pose relative_to='base_link' degrees="true">0.0885 0.0505 0 0 0 45</pose>
       <parent>base_link</parent>
       <child>coxa_fl_link</child>
       <axis>
@@ -676,9 +676,9 @@
       </physics>
     </joint>
     <link name='coxa_fl_link'>
-      <pose relative_to='coxa_fl_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='coxa_fl_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0.01425 0 0 0 1.5708 0</pose>
+        <pose degrees="true">0.01425 0 0 0 90 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>9.26875e-06</ixx>
@@ -690,7 +690,7 @@
         </inertia>
       </inertial>
       <collision name='coxa_fl_link_collision'>
-        <pose>0.01425 0 0 0 1.5708 0</pose>
+        <pose degrees="true">0.01425 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.0285</length>
@@ -711,7 +711,7 @@
         </surface>
       </collision>
       <visual name='coxa_fl_link_visual'>
-        <pose>0 0 0.0196 0 -0 0</pose>
+        <pose>0 0 0.0196 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -738,7 +738,7 @@
       <velocity_decay/>
     </link>
     <joint name='femur_fl_joint' type='revolute'>
-      <pose relative_to='coxa_fl_link'>0.0285 0 0 0 -0 0</pose>
+      <pose relative_to='coxa_fl_link'>0.0285 0 0 0 0 0</pose>
       <parent>coxa_fl_link</parent>
       <child>femur_fl_link</child>
       <axis>
@@ -764,7 +764,7 @@
       </physics>
     </joint>
     <link name='femur_fl_link'>
-      <pose relative_to='femur_fl_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='femur_fl_joint'>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0.0381 0 0 0 1.5708 0</pose>
         <mass>0.1</mass>
@@ -778,7 +778,7 @@
         </inertia>
       </inertial>
       <collision name='femur_fl_link_collision'>
-        <pose>0.0381 0 0 0 1.5708 0</pose>
+        <pose degrees="true">0.0381 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.0762</length>
@@ -799,7 +799,7 @@
         </surface>
       </collision>
       <visual name='femur_fl_link_visual'>
-        <pose>0 -0.026 0 0 -0 0</pose>
+        <pose>0 -0.026 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -826,7 +826,7 @@
       <velocity_decay/>
     </link>
     <joint name='tibia_fl_joint' type='revolute'>
-      <pose relative_to='femur_fl_link'>0.0762 0 0 0 -0 0</pose>
+      <pose relative_to='femur_fl_link'>0.0762 0 0 0 0 0</pose>
       <parent>femur_fl_link</parent>
       <child>tibia_fl_link</child>
       <axis>
@@ -852,7 +852,7 @@
       </physics>
     </joint>
     <link name='tibia_fl_link'>
-      <pose relative_to='tibia_fl_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='tibia_fl_joint'>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 -0.051 0 -0 0</pose>
         <mass>0.1</mass>
@@ -866,7 +866,7 @@
         </inertia>
       </inertial>
       <collision name='tibia_fl_link_collision'>
-        <pose>0 0 -0.051 0 -0 0</pose>
+        <pose>0 0 -0.051 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.102</length>
@@ -887,7 +887,7 @@
         </surface>
       </collision>
       <collision name='tibia_fl_link_fixed_joint_lump__foot_fl_link_collision_1'>
-        <pose>0 0 -0.102 0 -0 0</pose>
+        <pose>0 0 -0.102 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -915,7 +915,7 @@
         </surface>
       </collision>
       <visual name='tibia_fl_link_visual'>
-        <pose>0 -0.0185 0 0 -0 0</pose>
+        <pose>0 -0.0185 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -943,7 +943,7 @@
       <velocity_decay/>
     </link>
     <joint name='coxa_fr_joint' type='revolute'>
-      <pose relative_to='base_link'>0.0885 -0.0505 0 0 0 -0.785398</pose>
+      <pose relative_to='base_link' degrees="true">0.0885 -0.0505 0 0 0 -45</pose>
       <parent>base_link</parent>
       <child>coxa_fr_link</child>
       <axis>
@@ -969,7 +969,7 @@
       </physics>
     </joint>
     <link name='coxa_fr_link'>
-      <pose relative_to='coxa_fr_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='coxa_fr_joint'>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0.01425 0 0 0 1.5708 0</pose>
         <mass>0.1</mass>
@@ -1004,7 +1004,7 @@
         </surface>
       </collision>
       <visual name='coxa_fr_link_visual'>
-        <pose>0 0 0.0196 0 -0 0</pose>
+        <pose>0 0 0.0196 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -1031,7 +1031,7 @@
       <velocity_decay/>
     </link>
     <joint name='femur_fr_joint' type='revolute'>
-      <pose relative_to='coxa_fr_link'>0.0285 0 0 0 -0 0</pose>
+      <pose relative_to='coxa_fr_link'>0.0285 0 0 0 0 0</pose>
       <parent>coxa_fr_link</parent>
       <child>femur_fr_link</child>
       <axis>
@@ -1057,7 +1057,7 @@
       </physics>
     </joint>
     <link name='femur_fr_link'>
-      <pose relative_to='femur_fr_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='femur_fr_joint'>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0.0381 0 0 0 1.5708 0</pose>
         <mass>0.1</mass>
@@ -1071,7 +1071,7 @@
         </inertia>
       </inertial>
       <collision name='femur_fr_link_collision'>
-        <pose>0.0381 0 0 0 1.5708 0</pose>
+        <pose degrees="true">0.0381 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.0762</length>
@@ -1092,7 +1092,7 @@
         </surface>
       </collision>
       <visual name='femur_fr_link_visual'>
-        <pose>0 0.026 0 0 -0 0</pose>
+        <pose>0 0.026 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -1119,7 +1119,7 @@
       <velocity_decay/>
     </link>
     <joint name='tibia_fr_joint' type='revolute'>
-      <pose relative_to='femur_fr_link'>0.0762 0 0 0 -0 0</pose>
+      <pose relative_to='femur_fr_link'>0.0762 0 0 0 0 0</pose>
       <parent>femur_fr_link</parent>
       <child>tibia_fr_link</child>
       <axis>
@@ -1145,9 +1145,9 @@
       </physics>
     </joint>
     <link name='tibia_fr_link'>
-      <pose relative_to='tibia_fr_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='tibia_fr_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 -0.051 0 -0 0</pose>
+        <pose>0 0 -0.051 0 0 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>8.92e-05</ixx>
@@ -1159,7 +1159,7 @@
         </inertia>
       </inertial>
       <collision name='tibia_fr_link_collision'>
-        <pose>0 0 -0.051 0 -0 0</pose>
+        <pose>0 0 -0.051 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.102</length>
@@ -1180,7 +1180,7 @@
         </surface>
       </collision>
       <collision name='tibia_fr_link_fixed_joint_lump__foot_fr_link_collision_1'>
-        <pose>0 0 -0.102 0 -0 0</pose>
+        <pose>0 0 -0.102 0 0 0</pose>
         <geometry>
           <sphere>
             <radius>0.01</radius>
@@ -1208,7 +1208,7 @@
         </surface>
       </collision>
       <visual name='tibia_fr_link_visual'>
-        <pose>0 0.0185 0 0 -0 0</pose>
+        <pose>0 0.0185 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -1251,7 +1251,7 @@
         </inertia>
       </inertial>
       <sensor name="imu_sensor" type="imu">
-        <pose>0 0 0 3.141593 0 0</pose>
+        <pose degrees="true">0 0 0 180 0 0</pose>
         <always_on>1</always_on>
         <update_rate>1000.0</update_rate>
       </sensor>
@@ -1334,18 +1334,8 @@
       <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>
       <lock_step>1</lock_step>
 
-      <!-- Frame conventions
-        modelXYZToAirplaneXForwardZDown:
-          - transforms body frame from orientation in Gazebo to NED
-
-        gazeboXYZToNED
-          - transforms world from Gazebo convention xyz = N -E -D
-            to ArduPilot convention xyz = NED
-
-        Vehicle is oriented x-forward, y-left, z-up
-      -->
-      <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 0</modelXYZToAirplaneXForwardZDown>
-      <gazeboXYZToNED>0 0 0 3.141593 0 0</gazeboXYZToNED>
+      <modelXYZToAirplaneXForwardZDown degrees="true">0 0 0 180 0 0</modelXYZToAirplaneXForwardZDown>
+      <gazeboXYZToNED degrees="true">0 0 0 180 0 90</gazeboXYZToNED>
 
       <!-- Sensors -->
       <imuName>imu_sensor</imuName>

--- a/Gazebo/models/sawppy/model.sdf
+++ b/Gazebo/models/sawppy/model.sdf
@@ -16,7 +16,7 @@
         </inertia>
       </inertial>
       <collision name='base_link_collision'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.01 0.01 0.01</size>
@@ -32,7 +32,7 @@
         </surface>
       </collision>
       <collision name='base_link_fixed_joint_lump__body_box_link_collision_1'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.425 0.285 0.093</size>
@@ -48,7 +48,7 @@
         </surface>
       </collision>
       <visual name='base_link_visual'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.01 0.01 0.01</size>
@@ -61,7 +61,7 @@
         </material>
       </visual>
       <visual name='base_link_fixed_joint_lump__body_box_link_visual_1'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -79,7 +79,7 @@
       <velocity_decay/>
     </link>
     <joint name='diff_brace_joint' type='revolute'>
-      <pose relative_to='base_link'>0 0 0.0681 0 -0 0</pose>
+      <pose relative_to='base_link'>0 0 0.0681 0 0 0</pose>
       <parent>base_link</parent>
       <child>diff_brace_link</child>
       <axis>
@@ -110,9 +110,9 @@
       </physics>
     </joint>
     <link name='diff_brace_link'>
-      <pose relative_to='diff_brace_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='diff_brace_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 1.5708</pose>
+        <pose degrees="true">0 0 0 0 0 90</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>3.75e-06</ixx>
@@ -124,7 +124,7 @@
         </inertia>
       </inertial>
       <collision name='diff_brace_link_collision'>
-        <pose>0 0 0 0 -0 1.5708</pose>
+        <pose degrees="true">0 0 0 0 0 90</pose>
         <geometry>
           <box>
             <size>0.2 0.015 0.015</size>
@@ -140,7 +140,7 @@
         </surface>
       </collision>
       <visual name='diff_brace_link_visual'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -157,7 +157,7 @@
       <velocity_decay/>
     </link>
     <joint name='laser_joint' type='fixed'>
-      <pose relative_to='base_link'>0.152 0.078 0.05 0 -0 0</pose>
+      <pose relative_to='base_link'>0.152 0.078 0.05 0 0 0</pose>
       <parent>base_link</parent>
       <child>laser</child>
       <axis>
@@ -181,9 +181,9 @@
       </physics>
     </joint>
     <link name='laser'>
-      <pose relative_to='laser_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='laser_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.15</mass>
         <inertia>
           <ixx>9.09375e-05</ixx>
@@ -195,7 +195,7 @@
         </inertia>
       </inertial>
       <collision name='laser_collision'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.06</length>
@@ -212,7 +212,7 @@
         </surface>
       </collision>
       <visual name='laser_visual'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -232,7 +232,7 @@
         <update_rate>5</update_rate>
         <visualize>0</visualize>
         <topic>sensors/laser</topic>
-        <pose>0 0 0.045 0 -0 0</pose>
+        <pose>0 0 0.045 0 0 0</pose>
         <ray>
           <scan>
             <horizontal>
@@ -266,7 +266,7 @@
       </sensor> -->
     </link>
     <joint name='left_rocker_joint' type='revolute'>
-      <pose relative_to='base_link'>0.071 0.155 0.0118 0 -0 0</pose>
+      <pose relative_to='base_link'>0.071 0.155 0.0118 0 0 0</pose>
       <parent>base_link</parent>
       <child>left_rocker_link</child>
       <axis>
@@ -297,9 +297,9 @@
       </physics>
     </joint>
     <link name='left_rocker_link'>
-      <pose relative_to='left_rocker_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='left_rocker_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.25</mass>
         <inertia>
           <ixx>9.375e-06</ixx>
@@ -311,7 +311,7 @@
         </inertia>
       </inertial>
       <collision name='left_rocker_link_collision'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.1 0.015 0.015</size>
@@ -327,7 +327,7 @@
         </surface>
       </collision>
       <visual name='left_rocker_link_visual'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -344,7 +344,7 @@
       <velocity_decay/>
     </link>
     <joint name='front_left_steer_joint' type='revolute'>
-      <pose relative_to='left_rocker_link'>0.2116 0.075 -0.0279 0 -0 0</pose>
+      <pose relative_to='left_rocker_link'>0.2116 0.075 -0.0279 0 0 0</pose>
       <parent>left_rocker_link</parent>
       <child>front_left_steer_link</child>
       <axis>
@@ -371,9 +371,9 @@
       </physics>
     </joint>
     <link name='front_left_steer_link'>
-      <pose relative_to='front_left_steer_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='front_left_steer_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.25</mass>
         <inertia>
           <ixx>0.000416667</ixx>
@@ -385,7 +385,7 @@
         </inertia>
       </inertial>
       <collision name='front_left_steer_link_collision'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.1 0.1 0.1</size>
@@ -401,7 +401,7 @@
         </surface>
       </collision>
       <visual name='front_left_steer_link_visual'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -418,7 +418,7 @@
       <velocity_decay/>
     </link>
     <joint name='front_left_wheel_joint' type='revolute'>
-      <pose relative_to='front_left_steer_link'>0 0 -0.132 0 -0 0</pose>
+      <pose relative_to='front_left_steer_link'>0 0 -0.132 0 0 0</pose>
       <parent>front_left_steer_link</parent>
       <child>front_left_wheel_link</child>
       <axis>
@@ -445,9 +445,9 @@
       </physics>
     </joint>
     <link name='front_left_wheel_link'>
-      <pose relative_to='front_left_wheel_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='front_left_wheel_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.25</mass>
         <inertia>
           <ixx>0.000433333</ixx>
@@ -459,7 +459,7 @@
         </inertia>
       </inertial>
       <collision name='front_left_wheel_link_collision'>
-        <pose>0 0 0 1.5708 -0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.1</length>
@@ -476,7 +476,7 @@
         </surface>
       </collision>
       <visual name='front_left_wheel_link_visual'>
-        <pose>0 0 0 1.5708 -0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -493,7 +493,7 @@
       <velocity_decay/>
     </link>
     <joint name='left_bogie_joint' type='revolute'>
-      <pose relative_to='left_rocker_link'>-0.181 0.025 -0.062 0 -0 0</pose>
+      <pose relative_to='left_rocker_link'>-0.181 0.025 -0.062 0 0 0</pose>
       <parent>left_rocker_link</parent>
       <child>left_bogie_link</child>
       <axis>
@@ -524,9 +524,9 @@
       </physics>
     </joint>
     <link name='left_bogie_link'>
-      <pose relative_to='left_bogie_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='left_bogie_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.25</mass>
         <inertia>
           <ixx>9.375e-06</ixx>
@@ -538,7 +538,7 @@
         </inertia>
       </inertial>
       <collision name='left_bogie_link_collision'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.1 0.015 0.015</size>
@@ -554,7 +554,7 @@
         </surface>
       </collision>
       <visual name='left_bogie_link_visual'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -571,7 +571,7 @@
       <velocity_decay/>
     </link>
     <joint name='back_left_steer_joint' type='revolute'>
-      <pose relative_to='left_bogie_link'>-0.149 0.05 0.0338 0 -0 0</pose>
+      <pose relative_to='left_bogie_link'>-0.149 0.05 0.0338 0 0 0</pose>
       <parent>left_bogie_link</parent>
       <child>back_left_steer_link</child>
       <axis>
@@ -598,9 +598,9 @@
       </physics>
     </joint>
     <link name='back_left_steer_link'>
-      <pose relative_to='back_left_steer_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='back_left_steer_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.25</mass>
         <inertia>
           <ixx>0.000416667</ixx>
@@ -612,7 +612,7 @@
         </inertia>
       </inertial>
       <collision name='back_left_steer_link_collision'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.1 0.1 0.1</size>
@@ -628,7 +628,7 @@
         </surface>
       </collision>
       <visual name='back_left_steer_link_visual'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -645,7 +645,7 @@
       <velocity_decay/>
     </link>
     <joint name='back_left_wheel_joint' type='revolute'>
-      <pose relative_to='back_left_steer_link'>0 0 -0.132 0 -0 0</pose>
+      <pose relative_to='back_left_steer_link'>0 0 -0.132 0 0 0</pose>
       <parent>back_left_steer_link</parent>
       <child>back_left_wheel_link</child>
       <axis>
@@ -672,9 +672,9 @@
       </physics>
     </joint>
     <link name='back_left_wheel_link'>
-      <pose relative_to='back_left_wheel_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='back_left_wheel_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.25</mass>
         <inertia>
           <ixx>0.000433333</ixx>
@@ -686,7 +686,7 @@
         </inertia>
       </inertial>
       <collision name='back_left_wheel_link_collision'>
-        <pose>0 0 0 1.5708 -0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.1</length>
@@ -703,7 +703,7 @@
         </surface>
       </collision>
       <visual name='back_left_wheel_link_visual'>
-        <pose>0 0 0 1.5708 -0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -720,7 +720,7 @@
       <velocity_decay/>
     </link>
     <joint name='mid_left_wheel_joint' type='revolute'>
-      <pose relative_to='left_bogie_link'>0.1063 0.0929 -0.0959 0 -0 0</pose>
+      <pose relative_to='left_bogie_link'>0.1063 0.0929 -0.0959 0 0 0</pose>
       <parent>left_bogie_link</parent>
       <child>mid_left_wheel_link</child>
       <axis>
@@ -747,9 +747,9 @@
       </physics>
     </joint>
     <link name='mid_left_wheel_link'>
-      <pose relative_to='mid_left_wheel_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='mid_left_wheel_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.25</mass>
         <inertia>
           <ixx>0.000433333</ixx>
@@ -761,7 +761,7 @@
         </inertia>
       </inertial>
       <collision name='mid_left_wheel_link_collision'>
-        <pose>0 0 0 1.5708 -0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.1</length>
@@ -778,7 +778,7 @@
         </surface>
       </collision>
       <visual name='mid_left_wheel_link_visual'>
-        <pose>0 0 0 1.5708 -0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -795,7 +795,7 @@
       <velocity_decay/>
     </link>
     <joint name='right_rocker_joint' type='revolute'>
-      <pose relative_to='base_link'>0.071 -0.155 0.0118 0 -0 0</pose>
+      <pose relative_to='base_link'>0.071 -0.155 0.0118 0 0 0</pose>
       <parent>base_link</parent>
       <child>right_rocker_link</child>
       <axis>
@@ -826,9 +826,9 @@
       </physics>
     </joint>
     <link name='right_rocker_link'>
-      <pose relative_to='right_rocker_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='right_rocker_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.25</mass>
         <inertia>
           <ixx>9.375e-06</ixx>
@@ -840,7 +840,7 @@
         </inertia>
       </inertial>
       <collision name='right_rocker_link_collision'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.1 0.015 0.015</size>
@@ -856,7 +856,7 @@
         </surface>
       </collision>
       <visual name='right_rocker_link_visual'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -873,7 +873,7 @@
       <velocity_decay/>
     </link>
     <joint name='front_right_steer_joint' type='revolute'>
-      <pose relative_to='right_rocker_link'>0.2116 -0.075 -0.0279 0 -0 0</pose>
+      <pose relative_to='right_rocker_link'>0.2116 -0.075 -0.0279 0 0 0</pose>
       <parent>right_rocker_link</parent>
       <child>front_right_steer_link</child>
       <axis>
@@ -900,9 +900,9 @@
       </physics>
     </joint>
     <link name='front_right_steer_link'>
-      <pose relative_to='front_right_steer_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='front_right_steer_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.25</mass>
         <inertia>
           <ixx>0.000416667</ixx>
@@ -914,7 +914,7 @@
         </inertia>
       </inertial>
       <collision name='front_right_steer_link_collision'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.1 0.1 0.1</size>
@@ -930,7 +930,7 @@
         </surface>
       </collision>
       <visual name='front_right_steer_link_visual'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -947,7 +947,7 @@
       <velocity_decay/>
     </link>
     <joint name='front_right_wheel_joint' type='revolute'>
-      <pose relative_to='front_right_steer_link'>0 0 -0.132 0 -0 0</pose>
+      <pose relative_to='front_right_steer_link'>0 0 -0.132 0 0 0</pose>
       <parent>front_right_steer_link</parent>
       <child>front_right_wheel_link</child>
       <axis>
@@ -974,9 +974,9 @@
       </physics>
     </joint>
     <link name='front_right_wheel_link'>
-      <pose relative_to='front_right_wheel_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='front_right_wheel_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.25</mass>
         <inertia>
           <ixx>0.000433333</ixx>
@@ -988,7 +988,7 @@
         </inertia>
       </inertial>
       <collision name='front_right_wheel_link_collision'>
-        <pose>0 0 0 -1.5708 0 0</pose>
+        <pose degrees="true">0 0 0 -90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.1</length>
@@ -1005,7 +1005,7 @@
         </surface>
       </collision>
       <visual name='front_right_wheel_link_visual'>
-        <pose>0 0 0 -1.5708 0 0</pose>
+        <pose degrees="true">0 0 0 -90 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -1022,7 +1022,7 @@
       <velocity_decay/>
     </link>
     <joint name='right_bogie_joint' type='revolute'>
-      <pose relative_to='right_rocker_link'>-0.181 -0.025 -0.062 0 -0 0</pose>
+      <pose relative_to='right_rocker_link'>-0.181 -0.025 -0.062 0 0 0</pose>
       <parent>right_rocker_link</parent>
       <child>right_bogie_link</child>
       <axis>
@@ -1053,9 +1053,9 @@
       </physics>
     </joint>
     <link name='right_bogie_link'>
-      <pose relative_to='right_bogie_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='right_bogie_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.25</mass>
         <inertia>
           <ixx>9.375e-06</ixx>
@@ -1067,7 +1067,7 @@
         </inertia>
       </inertial>
       <collision name='right_bogie_link_collision'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.1 0.015 0.015</size>
@@ -1083,7 +1083,7 @@
         </surface>
       </collision>
       <visual name='right_bogie_link_visual'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -1100,7 +1100,7 @@
       <velocity_decay/>
     </link>
     <joint name='back_right_steer_joint' type='revolute'>
-      <pose relative_to='right_bogie_link'>-0.149 -0.05 0.0338 0 -0 0</pose>
+      <pose relative_to='right_bogie_link'>-0.149 -0.05 0.0338 0 0 0</pose>
       <parent>right_bogie_link</parent>
       <child>back_right_steer_link</child>
       <axis>
@@ -1127,9 +1127,9 @@
       </physics>
     </joint>
     <link name='back_right_steer_link'>
-      <pose relative_to='back_right_steer_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='back_right_steer_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.25</mass>
         <inertia>
           <ixx>0.000416667</ixx>
@@ -1141,7 +1141,7 @@
         </inertia>
       </inertial>
       <collision name='back_right_steer_link_collision'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.1 0.1 0.1</size>
@@ -1157,7 +1157,7 @@
         </surface>
       </collision>
       <visual name='back_right_steer_link_visual'>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -1174,7 +1174,7 @@
       <velocity_decay/>
     </link>
     <joint name='back_right_wheel_joint' type='revolute'>
-      <pose relative_to='back_right_steer_link'>0 0 -0.132 0 -0 0</pose>
+      <pose relative_to='back_right_steer_link'>0 0 -0.132 0 0 0</pose>
       <parent>back_right_steer_link</parent>
       <child>back_right_wheel_link</child>
       <axis>
@@ -1201,9 +1201,9 @@
       </physics>
     </joint>
     <link name='back_right_wheel_link'>
-      <pose relative_to='back_right_wheel_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='back_right_wheel_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.25</mass>
         <inertia>
           <ixx>0.000433333</ixx>
@@ -1215,7 +1215,7 @@
         </inertia>
       </inertial>
       <collision name='back_right_wheel_link_collision'>
-        <pose>0 0 0 -1.5708 0 0</pose>
+        <pose degrees="true">0 0 0 -90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.1</length>
@@ -1232,7 +1232,7 @@
         </surface>
       </collision>
       <visual name='back_right_wheel_link_visual'>
-        <pose>0 0 0 -1.5708 0 0</pose>
+        <pose degrees="true">0 0 0 -90 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -1249,7 +1249,7 @@
       <velocity_decay/>
     </link>
     <joint name='mid_right_wheel_joint' type='revolute'>
-      <pose relative_to='right_bogie_link'>0.1063 -0.0929 -0.0959 0 -0 0</pose>
+      <pose relative_to='right_bogie_link'>0.1063 -0.0929 -0.0959 0 0 0</pose>
       <parent>right_bogie_link</parent>
       <child>mid_right_wheel_link</child>
       <axis>
@@ -1276,9 +1276,9 @@
       </physics>
     </joint>
     <link name='mid_right_wheel_link'>
-      <pose relative_to='mid_right_wheel_joint'>0 0 0 0 -0 0</pose>
+      <pose relative_to='mid_right_wheel_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 -0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.25</mass>
         <inertia>
           <ixx>0.000433333</ixx>
@@ -1290,7 +1290,7 @@
         </inertia>
       </inertial>
       <collision name='mid_right_wheel_link_collision'>
-        <pose>0 0 0 -1.5708 0 0</pose>
+        <pose degrees="true">0 0 0 -90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.1</length>
@@ -1307,7 +1307,7 @@
         </surface>
       </collision>
       <visual name='mid_right_wheel_link_visual'>
-        <pose>0 0 0 -1.5708 0 0</pose>
+        <pose degrees="true">0 0 0 -90 0 0</pose>
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
@@ -1324,9 +1324,9 @@
       <velocity_decay/>
     </link>
     <link name='left_turnbuckle_link'>
-      <pose>0.035 0.17 0.07 0 -0 0</pose>
+      <pose>0.035 0.17 0.07 0 0 0</pose>
       <visual name='left_turnbuckle_visual'>
-        <pose>0 0 0 1.570 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <mesh>
             <uri>model://sawppy/meshes/bases/turnbuckle.stl</uri>
@@ -1339,7 +1339,7 @@
         </material>
       </visual>
       <collision name='left_turnbuckle_collision'>
-        <pose>0 0 0 0 1.5708 0</pose>
+        <pose degrees="true">0 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.07</length>
@@ -1360,20 +1360,20 @@
       </inertial>
     </link>
     <!-- <joint name='back_left_turnbuckle_joint' type='ball'>
-      <pose>-0.035 0 0 0 -0 0</pose>
+      <pose>-0.035 0 0 0 0 0</pose>
       <parent>diff_brace_link</parent>
       <child>left_turnbuckle_link</child>
     </joint> -->
     <!-- <joint name='front_left_turnbuckle_joint' type='ball'> -->
     <joint name='front_left_turnbuckle_joint' type='fixed'>
-      <pose>0.035 0 0 0 -0 0</pose>
+      <pose>0.035 0 0 0 0 0</pose>
       <parent>left_rocker_link</parent>
       <child>left_turnbuckle_link</child>
     </joint>
     <link name='right_turnbuckle_link'>
       <pose>0.035 -0.17 0.07 0 0 0</pose>
       <visual name='right_turnbuckle_visual'>
-        <pose>0 0 0 1.5708 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <mesh>
             <uri>model://sawppy/meshes/bases/turnbuckle.stl</uri>
@@ -1386,7 +1386,7 @@
         </material>
       </visual>
       <collision name='right_turnbuckle_collision'>
-        <pose>0 0 0 0 1.5708 0</pose>
+        <pose degrees="true">0 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.07</length>
@@ -1407,7 +1407,7 @@
       </inertial>
     </link>
     <!-- <joint name='back_right_turnbuckle_joint' type='ball'>
-      <pose>-0.035 0 0 0 -0 0</pose>
+      <pose>-0.035 0 0 0 0 0</pose>
       <parent>diff_brace_link</parent>
       <child>right_turnbuckle_link</child>
     </joint> -->
@@ -1433,7 +1433,7 @@
         </inertia>
       </inertial>
       <sensor name="imu_sensor" type="imu">
-        <pose>0 0 0 3.141593 0 0</pose>
+        <pose degrees="true">0 0 0 180 0 0</pose>
         <always_on>1</always_on>
         <update_rate>1000.0</update_rate>
       </sensor>
@@ -1508,18 +1508,8 @@
       <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>
       <lock_step>1</lock_step>
 
-      <!-- Frame conventions
-        modelXYZToAirplaneXForwardZDown:
-          - transforms body frame from orientation in Gazebo to NED
-
-        gazeboXYZToNED
-          - transforms world from Gazebo convention xyz = N -E -D
-            to ArduPilot convention xyz = NED
-
-        Vehicle is oriented x-forward, y-left, z-up
-      -->
-      <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 0</modelXYZToAirplaneXForwardZDown>
-      <gazeboXYZToNED>0 0 0 3.141593 0 0</gazeboXYZToNED>
+      <modelXYZToAirplaneXForwardZDown degrees="true">0 0 0 180 0 0</modelXYZToAirplaneXForwardZDown>
+      <gazeboXYZToNED degrees="true">0 0 0 180 0 90</gazeboXYZToNED>
 
       <!-- Sensors -->
       <imuName>imu_sensor</imuName>

--- a/Gazebo/models/skycat_tvbs/model.sdf
+++ b/Gazebo/models/skycat_tvbs/model.sdf
@@ -570,12 +570,12 @@
     </joint>
 
     <!-- plugins -->
-    <plugin filename="libgz-sim-joint-state-publisher-system.so"
+    <plugin filename="gz-sim-joint-state-publisher-system"
       name="gz::sim::systems::JointStatePublisher">
     </plugin>
 
     <!-- prop_left (cc) lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -592,7 +592,7 @@
       <upward>0 0 1</upward>
       <link_name>motor_left_link</link_name>
     </plugin>
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -611,7 +611,7 @@
     </plugin>
 
     <!-- prop_right (ccw) lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -628,7 +628,7 @@
       <upward>0 0 1</upward>
       <link_name>motor_right_link</link_name>
     </plugin>
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -647,7 +647,7 @@
     </plugin>
 
     <!-- wing lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.13</a0>
       <cla>3.7</cla>
@@ -665,7 +665,7 @@
       <link_name>base_link</link_name>
     </plugin>
     <!-- left_elevon lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.15</a0>
       <cla>6.8</cla>
@@ -685,7 +685,7 @@
       <control_joint_rad_to_cl>-5.0</control_joint_rad_to_cl>
     </plugin>
     <!-- right_elevon lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.15</a0>
       <cla>6.8</cla>
@@ -705,7 +705,7 @@
       <control_joint_rad_to_cl>-5.0</control_joint_rad_to_cl>
     </plugin>
     <!-- left_winglet lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.0</a0>
       <cla>4.752798721</cla>
@@ -723,7 +723,7 @@
       <link_name>base_link</link_name>
     </plugin>
     <!-- right_winglet lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.0</a0>
       <cla>4.752798721</cla>
@@ -741,32 +741,32 @@
       <link_name>base_link</link_name>
     </plugin>
 
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>elevon_left_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>elevon_right_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>tilt_left_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>tilt_right_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>motor_left_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>motor_right_joint</joint_name>
     </plugin>
 
-    <plugin name="ArduPilotPlugin" filename="libArduPilotPlugin.so">
+    <plugin name="ArduPilotPlugin" filename="ArduPilotPlugin">
       <!-- Port settings -->
       <fdm_addr>127.0.0.1</fdm_addr>
       <fdm_port_in>9002</fdm_port_in>

--- a/Gazebo/models/skycat_tvbs/model.sdf
+++ b/Gazebo/models/skycat_tvbs/model.sdf
@@ -546,7 +546,7 @@
         </inertia>
       </inertial>
       <sensor name="imu_sensor" type="imu">
-        <pose>0 0 0 3.141593 0 0</pose>
+        <pose degrees="true">0 0 0 180 0 0</pose>
         <always_on>1</always_on>
         <update_rate>1000.0</update_rate>
       </sensor>
@@ -783,8 +783,8 @@
 
         Vehicle is oriented x-forward, y-left, z-up
       -->
-      <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 0</modelXYZToAirplaneXForwardZDown>
-      <gazeboXYZToNED>0 0 0 3.141593 0 0</gazeboXYZToNED>
+      <modelXYZToAirplaneXForwardZDown degrees="true">0 0 0 180 0 0</modelXYZToAirplaneXForwardZDown>
+      <gazeboXYZToNED degrees="true">0 0 0 180 0 90</gazeboXYZToNED>
 
       <!-- Sensors -->
       <imuName>imu_sensor</imuName>

--- a/Gazebo/models/skywalker_x8/model.sdf
+++ b/Gazebo/models/skywalker_x8/model.sdf
@@ -43,7 +43,7 @@
         </material>
       </visual>
       <visual name='m4'>
-        <pose>-0.361 0 0.0 0 1.57 0</pose>
+        <pose degrees="true">-0.361 0 0.0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.035</length>
@@ -161,7 +161,7 @@
     </link>
 
     <link name='rotor_pusher'>
-      <pose>-0.385 0 0.0 0 1.57 0</pose>
+      <pose degrees="true">-0.385 0 0.0 0 90 0</pose>
       <inertial>
         <mass>0.025</mass>
         <inertia>
@@ -174,7 +174,7 @@
         </inertia>
       </inertial>
       <collision name='collision'>
-        <pose>0.0 0 0 0 0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.005</length>
@@ -331,7 +331,7 @@
         </inertia>
       </inertial>
       <sensor name="imu_sensor" type="imu">
-        <pose>0 0 0 3.141593 0 0</pose>
+        <pose degrees="true">0 0 0 180 0 0</pose>
         <always_on>1</always_on>
         <update_rate>1000.0</update_rate>
       </sensor>
@@ -551,18 +551,8 @@
       <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>
       <lock_step>1</lock_step>
 
-      <!-- Frame conventions
-        modelXYZToAirplaneXForwardZDown:
-          - transforms body frame from orientation in Gazebo to NED
-
-        gazeboXYZToNED
-          - transforms world from Gazebo convention xyz = N -E -D
-            to ArduPilot convention xyz = NED
-
-        VTOL is oriented x-forward, y-left, z-up
-      -->
-      <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 0</modelXYZToAirplaneXForwardZDown>
-      <gazeboXYZToNED>0 0 0 3.141593 0 0</gazeboXYZToNED>
+      <modelXYZToAirplaneXForwardZDown degrees="true">0 0 0 180 0 0</modelXYZToAirplaneXForwardZDown>
+      <gazeboXYZToNED degrees="true">0 0 0 180 0 90</gazeboXYZToNED>
 
       <!-- Sensors -->
       <imuName>imu_sensor</imuName>

--- a/Gazebo/models/skywalker_x8/model.sdf
+++ b/Gazebo/models/skywalker_x8/model.sdf
@@ -355,12 +355,12 @@
     </joint>
 
     <!-- plugins -->
-    <plugin filename="libgz-sim-joint-state-publisher-system.so"
+    <plugin filename="gz-sim-joint-state-publisher-system"
       name="gz::sim::systems::JointStatePublisher">
     </plugin>
 
     <!-- rotor_pusher lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.30</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -377,7 +377,7 @@
       <upward>0 0 1</upward>
       <link_name>rotor_pusher</link_name>
     </plugin>
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.30</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -395,7 +395,7 @@
       <link_name>rotor_pusher</link_name>
     </plugin>
     <!-- wing lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.13</a0>
       <cla>3.7</cla>
@@ -413,7 +413,7 @@
       <link_name>base_link</link_name>
     </plugin>
     <!-- left_elevon lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.15</a0>
       <cla>6.8</cla>
@@ -433,7 +433,7 @@
       <control_joint_rad_to_cl>-5.0</control_joint_rad_to_cl>
     </plugin>
     <!-- right_elevon lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.15</a0>
       <cla>6.8</cla>
@@ -453,7 +453,7 @@
       <control_joint_rad_to_cl>-5.0</control_joint_rad_to_cl>
     </plugin>
     <!-- left_winglet lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.0</a0>
       <cla>4.752798721</cla>
@@ -471,7 +471,7 @@
       <link_name>base_link</link_name>
     </plugin>
     <!-- right_winglet lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.0</a0>
       <cla>4.752798721</cla>
@@ -491,7 +491,7 @@
 
     <!-- original from standard_vtol -->
     <!-- left_wing_lift-drag -->
-    <!-- <plugin filename="libgz-sim-lift-drag-system.so"
+    <!-- <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.05984281113</a0>
       <cla>4.752798721</cla>
@@ -511,7 +511,7 @@
       <control_joint_rad_to_cl>-1.0</control_joint_rad_to_cl>
     </plugin> -->
     <!-- right_wing_lift-drag -->
-    <!-- <plugin filename="libgz-sim-lift-drag-system.so"
+    <!-- <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.05984281113</a0>
       <cla>4.752798721</cla>
@@ -531,20 +531,20 @@
       <control_joint_rad_to_cl>-1.0</control_joint_rad_to_cl>
     </plugin> -->
 
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>rotor_pusher_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>left_elevon_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>right_elevon_joint</joint_name>
     </plugin>
 
-    <plugin name="ArduPilotPlugin" filename="libArduPilotPlugin.so">
+    <plugin name="ArduPilotPlugin" filename="ArduPilotPlugin">
       <!-- Port settings -->
       <fdm_addr>127.0.0.1</fdm_addr>
       <fdm_port_in>9002</fdm_port_in>

--- a/Gazebo/models/skywalker_x8_quad/model.sdf
+++ b/Gazebo/models/skywalker_x8_quad/model.sdf
@@ -89,7 +89,7 @@
         </material>
       </visual>
       <visual name='m0'>
-        <pose>0.49 -0.35 0.045 -0.052 0 0</pose>
+        <pose degrees="true">0.49 -0.35 0.045 -3 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.035</length>
@@ -113,7 +113,7 @@
         </material>
       </visual>
       <visual name='m1'>
-        <pose>-0.49 0.35 0.045 0.052 0 0</pose>
+        <pose degrees="true">-0.49 0.35 0.045 3 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.035</length>
@@ -137,7 +137,7 @@
         </material>
       </visual>
       <visual name='m2'>
-        <pose>0.49 0.35 0.045 0.052 0 0</pose>
+        <pose degrees="true">0.49 0.35 0.045 3 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.035</length>
@@ -161,7 +161,7 @@
         </material>
       </visual>
       <visual name='m3'>
-        <pose>-0.49 -0.35 0.045 -0.052 0 0</pose>
+        <pose degrees="true">-0.49 -0.35 0.045 -3 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.035</length>
@@ -185,7 +185,7 @@
         </material>
       </visual>
       <visual name='m4'>
-        <pose>-0.361 0 0.0 0 1.57 0</pose>
+        <pose degrees="true">-0.361 0 0.0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.035</length>
@@ -277,7 +277,7 @@
     </link>
 
     <link name='rotor_0'>
-      <pose>0.49 -0.35 0.07 -0.052 0 0</pose>
+      <pose degrees="true">0.49 -0.35 0.07 -3 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
         <mass>0.025</mass>
@@ -336,7 +336,7 @@
     </joint>
 
     <link name='rotor_1'>
-      <pose>-0.49 0.35 0.07 0.052 0 0</pose>
+      <pose degrees="true">-0.49 0.35 0.07 3 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
         <mass>0.025</mass>
@@ -395,7 +395,7 @@
     </joint>
 
     <link name='rotor_2'>
-      <pose>0.49 0.35 0.07 0.052 0 0</pose>
+      <pose degrees="true">0.49 0.35 0.07 3 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
         <mass>0.025</mass>
@@ -454,7 +454,7 @@
     </joint>
 
     <link name='rotor_3'>
-      <pose>-0.49 -0.35 0.07 -0.052 0 0</pose>
+      <pose degrees="true">-0.49 -0.35 0.07 -3 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
         <mass>0.025</mass>
@@ -513,7 +513,7 @@
     </joint>
 
     <link name='rotor_pusher'>
-      <pose>-0.385 0 0.0 0 1.57 0</pose>
+      <pose degrees="true">-0.385 0 0.0 0 90 0</pose>
       <inertial>
         <mass>0.025</mass>
         <inertia>
@@ -526,7 +526,7 @@
         </inertia>
       </inertial>
       <collision name='collision'>
-        <pose>0.0 0 0 0 0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.005</length>
@@ -683,7 +683,7 @@
         </inertia>
       </inertial>
       <sensor name="imu_sensor" type="imu">
-        <pose>0 0 0 3.141593 0 0</pose>
+        <pose degrees="true">0 0 0 180 0 0</pose>
         <always_on>1</always_on>
         <update_rate>1000.0</update_rate>
       </sensor>
@@ -1016,18 +1016,8 @@
       <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>
       <lock_step>1</lock_step>
 
-      <!-- Frame conventions
-        modelXYZToAirplaneXForwardZDown:
-          - transforms body frame from orientation in Gazebo to NED
-
-        gazeboXYZToNED
-          - transforms world from Gazebo convention xyz = N -E -D
-            to ArduPilot convention xyz = NED
-
-        VTOL is oriented x-forward, y-left, z-up
-      -->
-      <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 0</modelXYZToAirplaneXForwardZDown>
-      <gazeboXYZToNED>0 0 0 3.141593 0 0</gazeboXYZToNED>
+      <modelXYZToAirplaneXForwardZDown degrees="true">0 0 0 180 0 0</modelXYZToAirplaneXForwardZDown>
+      <gazeboXYZToNED degrees="true">0 0 0 180 0 90</gazeboXYZToNED>
 
       <!-- Sensors -->
       <imuName>imu_sensor</imuName>

--- a/Gazebo/models/skywalker_x8_quad/model.sdf
+++ b/Gazebo/models/skywalker_x8_quad/model.sdf
@@ -707,11 +707,11 @@
     </joint>
 
     <!-- plugins -->
-    <plugin filename="libgz-sim-joint-state-publisher-system.so"
+    <plugin filename="gz-sim-joint-state-publisher-system"
       name="gz::sim::systems::JointStatePublisher">
     </plugin>
     <!-- rotor_0 lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -728,7 +728,7 @@
       <upward>0 0 1</upward>
       <link_name>rotor_0</link_name>
     </plugin>
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -746,7 +746,7 @@
       <link_name>rotor_0</link_name>
     </plugin>
     <!-- rotor_1 lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -763,7 +763,7 @@
       <upward>0 0 1</upward>
       <link_name>rotor_1</link_name>
     </plugin>
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -781,7 +781,7 @@
       <link_name>rotor_1</link_name>
     </plugin>
     <!-- rotor_2 lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -798,7 +798,7 @@
       <upward>0 0 1</upward>
       <link_name>rotor_2</link_name>
     </plugin>
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -816,7 +816,7 @@
       <link_name>rotor_2</link_name>
     </plugin>
     <!-- rotor_3 lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -833,7 +833,7 @@
       <upward>0 0 1</upward>
       <link_name>rotor_3</link_name>
     </plugin>
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.3</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -851,7 +851,7 @@
       <link_name>rotor_3</link_name>
     </plugin>
     <!-- rotor_pusher lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.30</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -868,7 +868,7 @@
       <upward>0 0 1</upward>
       <link_name>rotor_pusher</link_name>
     </plugin>
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.30</a0>
       <alpha_stall>1.4</alpha_stall>
@@ -886,7 +886,7 @@
       <link_name>rotor_pusher</link_name>
     </plugin>
     <!-- wing lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.13</a0>
       <cla>3.7</cla>
@@ -904,7 +904,7 @@
       <link_name>base_link</link_name>
     </plugin>
     <!-- left_elevon lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.15</a0>
       <cla>6.8</cla>
@@ -924,7 +924,7 @@
       <control_joint_rad_to_cl>-5.0</control_joint_rad_to_cl>
     </plugin>
     <!-- right_elevon lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.15</a0>
       <cla>6.8</cla>
@@ -944,7 +944,7 @@
       <control_joint_rad_to_cl>-5.0</control_joint_rad_to_cl>
     </plugin>
     <!-- left_winglet lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.0</a0>
       <cla>4.752798721</cla>
@@ -962,7 +962,7 @@
       <link_name>base_link</link_name>
     </plugin>
     <!-- right_winglet lift-drag -->
-    <plugin filename="libgz-sim-lift-drag-system.so"
+    <plugin filename="gz-sim-lift-drag-system"
         name="gz::sim::systems::LiftDrag">
       <a0>0.0</a0>
       <cla>4.752798721</cla>
@@ -980,36 +980,36 @@
       <link_name>base_link</link_name>
     </plugin>
 
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>rotor_0_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>rotor_1_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>rotor_2_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>rotor_3_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>rotor_pusher_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>left_elevon_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>right_elevon_joint</joint_name>
     </plugin>
 
-    <plugin name="ArduPilotPlugin" filename="libArduPilotPlugin.so">
+    <plugin name="ArduPilotPlugin" filename="ArduPilotPlugin">
       <!-- Port settings -->
       <fdm_addr>127.0.0.1</fdm_addr>
       <fdm_port_in>9002</fdm_port_in>

--- a/Gazebo/models/sonoma_raceway/model.sdf
+++ b/Gazebo/models/sonoma_raceway/model.sdf
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
   <model name="sonoma_raceway">
-    <pose>145 290 -7.3 0 0 -1.570796327</pose>
+    <pose degrees="true">-290 145 -7.35 0 0 0</pose>
     <static>true</static>
     <link name="link">
       <collision name="collision">

--- a/Gazebo/models/swan_k1_hwing/model.sdf
+++ b/Gazebo/models/swan_k1_hwing/model.sdf
@@ -276,7 +276,7 @@
         </material>
       </visual> -->
       <visual name="motor_visual">
-        <pose>0 0 -0.008 0 -1.5707963 0</pose>
+        <pose degrees="true">0 0 -0.008 0 -90 0</pose>
         <geometry>
           <mesh>
             <uri>model://swan_k1_hwing/meshes/swan_k1_hwing_motor.dae</uri>
@@ -323,7 +323,7 @@
       </visual>
     </link>
     <joint name='motor1_joint' type='revolute'>
-      <pose relative_to="base_link">-0.015 -0.25 -0.16 0.174532925 1.396263402 0</pose>
+      <pose relative_to="base_link" degrees="true">-0.015 -0.25 -0.16 10 80 0</pose>
       <child>motor1_link</child>
       <parent>base_link</parent>
       <axis>
@@ -385,7 +385,7 @@
         </material>
       </visual> -->
       <visual name="motor_visual">
-        <pose>0 0 -0.008 0 -1.5707963 0</pose>
+        <pose degrees="true">0 0 -0.008 0 -90 0</pose>
         <geometry>
           <mesh>
             <uri>model://swan_k1_hwing/meshes/swan_k1_hwing_motor.dae</uri>
@@ -432,7 +432,7 @@
       </visual>
     </link>
     <joint name='motor2_joint' type='revolute'>
-      <pose relative_to="base_link">-0.015 0.25 0.16 -0.174532925 1.745329252 0</pose>
+      <pose relative_to="base_link" degrees="true">-0.015 0.25 0.16 -10 100 0</pose>
       <child>motor2_link</child>
       <parent>base_link</parent>
       <axis>
@@ -494,7 +494,7 @@
         </material>
       </visual> -->
       <visual name="motor_visual">
-        <pose>0 0 -0.008 0 -1.5707963 0</pose>
+        <pose degrees="true">0 0 -0.008 0 -90 0</pose>
         <geometry>
           <mesh>
             <uri>model://swan_k1_hwing/meshes/swan_k1_hwing_motor.dae</uri>
@@ -541,7 +541,7 @@
       </visual>
     </link>
     <joint name='motor3_joint' type='revolute'>
-      <pose relative_to="base_link">-0.015 0.25 -0.16 -0.174532925 1.396263402 0</pose>
+      <pose relative_to="base_link" degrees="true">-0.015 0.25 -0.16 -10 80 0</pose>
       <child>motor3_link</child>
       <parent>base_link</parent>
       <axis>
@@ -603,7 +603,7 @@
         </material>
       </visual> -->
       <visual name="motor_visual">
-        <pose>0 0 -0.008 0 -1.5707963 0</pose>
+        <pose degrees="true">0 0 -0.008 0 -90 0</pose>
         <geometry>
           <mesh>
             <uri>model://swan_k1_hwing/meshes/swan_k1_hwing_motor.dae</uri>
@@ -650,7 +650,7 @@
       </visual>
     </link>
     <joint name='motor4_joint' type='revolute'>
-      <pose relative_to="base_link">-0.015 -0.25 0.16 0.174532925 1.745329252 0</pose>
+      <pose relative_to="base_link" degrees="true">-0.015 -0.25 0.16 10 100 0</pose>
       <child>motor4_link</child>
       <parent>base_link</parent>
       <axis>
@@ -680,7 +680,7 @@
         </inertia>
       </inertial>
       <sensor name="imu_sensor" type="imu">
-        <pose>0 0 0 3.141593 0 0</pose>
+        <pose degrees="true">0 0 0 180 0 0</pose>
         <always_on>1</always_on>
         <update_rate>1000.0</update_rate>
       </sensor>
@@ -963,8 +963,8 @@
       <fdm_port_in>9002</fdm_port_in>
       <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>
       <lock_step>1</lock_step>
-      <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 0</modelXYZToAirplaneXForwardZDown>
-      <gazeboXYZToNED>0 0 0 3.141593 0 0</gazeboXYZToNED>
+      <modelXYZToAirplaneXForwardZDown degrees="true">0 0 0 180 0 0</modelXYZToAirplaneXForwardZDown>
+      <gazeboXYZToNED degrees="true">0 0 0 180 0 90</gazeboXYZToNED>
       <imuName>imu_sensor</imuName>
 
       <!-- 

--- a/Gazebo/models/wildthumper/model.sdf
+++ b/Gazebo/models/wildthumper/model.sdf
@@ -1762,7 +1762,7 @@
     </joint>
 
     <!-- plugins -->
-    <plugin filename="libgz-sim-joint-state-publisher-system.so"
+    <plugin filename="gz-sim-joint-state-publisher-system"
       name="gz::sim::systems::JointStatePublisher">
     </plugin>
     <plugin
@@ -1772,32 +1772,32 @@
       <robot_base_frame>base_link</robot_base_frame>
       <dimensions>3</dimensions>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>front_left_wheel_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>front_right_wheel_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>mid_left_wheel_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>mid_right_wheel_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>rear_left_wheel_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>rear_right_wheel_joint</joint_name>
     </plugin>
 
-    <plugin name="ArduPilotPlugin" filename="libArduPilotPlugin.so">
+    <plugin name="ArduPilotPlugin" filename="ArduPilotPlugin">
       <!-- Port settings -->
       <fdm_addr>127.0.0.1</fdm_addr>
       <fdm_port_in>9002</fdm_port_in>

--- a/Gazebo/models/wildthumper/model.sdf
+++ b/Gazebo/models/wildthumper/model.sdf
@@ -200,7 +200,7 @@
     <link name='front_left_motor_asm_link'>
       <pose relative_to='front_left_motor_asm_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0.025 0 90 0 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>2.723333333333334e-05</ixx>
@@ -212,7 +212,7 @@
         </inertia>
       </inertial>
       <collision name='front_left_motor_asm_link_collision'>
-        <pose>0 0 0 0 1.570796326794897 0</pose>
+        <pose degrees="true">0 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.064</length>
@@ -221,7 +221,7 @@
         </geometry>
       </collision>
       <collision name='front_left_motor_asm_link_collision_1'>
-        <pose>0 0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0.025 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -272,7 +272,7 @@
     <link name='front_left_wheel_link'>
       <pose relative_to='front_left_wheel_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <mass>0.19</mass>
         <inertia>
           <ixx>0.0002022409166666667</ixx>
@@ -284,7 +284,7 @@
         </inertia>
       </inertial>
       <collision name='front_left_wheel_link_collision'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.062</length>
@@ -304,7 +304,7 @@
         </surface>
       </collision>
       <collision name='front_left_wheel_link_fixed_joint_lump__front_left_wheel_adapter_link_collision_1'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.024</length>
@@ -313,7 +313,7 @@
         </geometry>
       </collision>
       <collision name='front_left_wheel_link_fixed_joint_lump__front_left_wheel_rim_link_collision_2'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -416,7 +416,7 @@
     <link name='front_right_motor_asm_link'>
       <pose relative_to='front_right_motor_asm_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 -0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 -0.025 0 90 0 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>2.723333333333334e-05</ixx>
@@ -428,7 +428,7 @@
         </inertia>
       </inertial>
       <collision name='front_right_motor_asm_link_collision'>
-        <pose>0 0 0 0 1.570796326794897 0</pose>
+        <pose degrees="true">0 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.064</length>
@@ -437,7 +437,7 @@
         </geometry>
       </collision>
       <collision name='front_right_motor_asm_link_collision_1'>
-        <pose>0 -0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 -0.025 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -488,7 +488,7 @@
     <link name='front_right_wheel_link'>
       <pose relative_to='front_right_wheel_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <mass>0.19</mass>
         <inertia>
           <ixx>0.0002022409166666667</ixx>
@@ -500,7 +500,7 @@
         </inertia>
       </inertial>
       <collision name='front_right_wheel_link_collision'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.062</length>
@@ -520,7 +520,7 @@
         </surface>
       </collision>
       <collision name='front_right_wheel_link_fixed_joint_lump__front_right_wheel_adapter_link_collision_1'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.024</length>
@@ -529,7 +529,7 @@
         </geometry>
       </collision>
       <collision name='front_right_wheel_link_fixed_joint_lump__front_right_wheel_rim_link_collision_2'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -694,7 +694,7 @@
     <link name='mid_left_motor_asm_link'>
       <pose relative_to='mid_left_motor_asm_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0.025 0 90 0 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>2.723333333333334e-05</ixx>
@@ -706,7 +706,7 @@
         </inertia>
       </inertial>
       <collision name='mid_left_motor_asm_link_collision'>
-        <pose>0 0 0 0 1.570796326794897 0</pose>
+        <pose degrees="true">0 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.064</length>
@@ -715,7 +715,7 @@
         </geometry>
       </collision>
       <collision name='mid_left_motor_asm_link_collision_1'>
-        <pose>0 0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0.025 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -766,7 +766,7 @@
     <link name='mid_left_wheel_link'>
       <pose relative_to='mid_left_wheel_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <mass>0.19</mass>
         <inertia>
           <ixx>0.0002022409166666667</ixx>
@@ -778,7 +778,7 @@
         </inertia>
       </inertial>
       <collision name='mid_left_wheel_link_collision'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.062</length>
@@ -798,7 +798,7 @@
         </surface>
       </collision>
       <collision name='mid_left_wheel_link_fixed_joint_lump__mid_left_wheel_adapter_link_collision_1'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.024</length>
@@ -807,7 +807,7 @@
         </geometry>
       </collision>
       <collision name='mid_left_wheel_link_fixed_joint_lump__mid_left_wheel_rim_link_collision_2'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -910,7 +910,7 @@
     <link name='mid_right_motor_asm_link'>
       <pose relative_to='mid_right_motor_asm_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 -0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 -0.025 0 90 0 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>2.723333333333334e-05</ixx>
@@ -922,7 +922,7 @@
         </inertia>
       </inertial>
       <collision name='mid_right_motor_asm_link_collision'>
-        <pose>0 0 0 0 1.570796326794897 0</pose>
+        <pose degrees="true">0 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.064</length>
@@ -931,7 +931,7 @@
         </geometry>
       </collision>
       <collision name='mid_right_motor_asm_link_collision_1'>
-        <pose>0 -0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 -0.025 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -982,7 +982,7 @@
     <link name='mid_right_wheel_link'>
       <pose relative_to='mid_right_wheel_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <mass>0.19</mass>
         <inertia>
           <ixx>0.0002022409166666667</ixx>
@@ -994,7 +994,7 @@
         </inertia>
       </inertial>
       <collision name='mid_right_wheel_link_collision'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.062</length>
@@ -1014,7 +1014,7 @@
         </surface>
       </collision>
       <collision name='mid_right_wheel_link_fixed_joint_lump__mid_right_wheel_adapter_link_collision_1'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.024</length>
@@ -1023,7 +1023,7 @@
         </geometry>
       </collision>
       <collision name='mid_right_wheel_link_fixed_joint_lump__mid_right_wheel_rim_link_collision_2'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -1250,7 +1250,7 @@
     <link name='rear_left_motor_asm_link'>
       <pose relative_to='rear_left_motor_asm_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0.025 0 90 0 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>2.723333333333334e-05</ixx>
@@ -1262,7 +1262,7 @@
         </inertia>
       </inertial>
       <collision name='rear_left_motor_asm_link_collision'>
-        <pose>0 0 0 0 1.570796326794897 0</pose>
+        <pose degrees="true">0 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.064</length>
@@ -1271,7 +1271,7 @@
         </geometry>
       </collision>
       <collision name='rear_left_motor_asm_link_collision_1'>
-        <pose>0 0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0.025 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -1322,7 +1322,7 @@
     <link name='rear_left_wheel_link'>
       <pose relative_to='rear_left_wheel_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <mass>0.19</mass>
         <inertia>
           <ixx>0.0002022409166666667</ixx>
@@ -1334,7 +1334,7 @@
         </inertia>
       </inertial>
       <collision name='rear_left_wheel_link_collision'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.062</length>
@@ -1354,7 +1354,7 @@
         </surface>
       </collision>
       <collision name='rear_left_wheel_link_fixed_joint_lump__rear_left_wheel_adapter_link_collision_1'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.024</length>
@@ -1363,7 +1363,7 @@
         </geometry>
       </collision>
       <collision name='rear_left_wheel_link_fixed_joint_lump__rear_left_wheel_rim_link_collision_2'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -1466,7 +1466,7 @@
     <link name='rear_right_motor_asm_link'>
       <pose relative_to='rear_right_motor_asm_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 -0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 -0.025 0 90 0 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>2.723333333333334e-05</ixx>
@@ -1478,7 +1478,7 @@
         </inertia>
       </inertial>
       <collision name='rear_right_motor_asm_link_collision'>
-        <pose>0 0 0 0 1.570796326794897 0</pose>
+        <pose degrees="true">0 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.064</length>
@@ -1487,7 +1487,7 @@
         </geometry>
       </collision>
       <collision name='rear_right_motor_asm_link_collision_1'>
-        <pose>0 -0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 -0.025 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -1538,7 +1538,7 @@
     <link name='rear_right_wheel_link'>
       <pose relative_to='rear_right_wheel_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <mass>0.19</mass>
         <inertia>
           <ixx>0.0002022409166666667</ixx>
@@ -1550,7 +1550,7 @@
         </inertia>
       </inertial>
       <collision name='rear_right_wheel_link_collision'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.062</length>
@@ -1570,7 +1570,7 @@
         </surface>
       </collision>
       <collision name='rear_right_wheel_link_fixed_joint_lump__rear_right_wheel_adapter_link_collision_1'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.024</length>
@@ -1579,7 +1579,7 @@
         </geometry>
       </collision>
       <collision name='rear_right_wheel_link_fixed_joint_lump__rear_right_wheel_rim_link_collision_2'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -1738,7 +1738,7 @@
         </inertia>
       </inertial>
       <sensor name="imu_sensor" type="imu">
-        <pose>0 0 0 3.141593 0 0</pose>
+        <pose degrees="true">0 0 0 180 0 0</pose>
         <always_on>1</always_on>
         <update_rate>1000.0</update_rate>
       </sensor>
@@ -1804,18 +1804,8 @@
       <connectionTimeoutMaxCount>5</connectionTimeoutMaxCount>
       <lock_step>1</lock_step>
 
-      <!-- Frame conventions
-        modelXYZToAirplaneXForwardZDown:
-          - transforms body frame from orientation in Gazebo to NED
-
-        gazeboXYZToNED
-          - transforms world from Gazebo convention xyz = N -E -D
-            to ArduPilot convention xyz = NED
-
-        Vehicle is oriented x-forward, y-left, z-up
-      -->
-      <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 0</modelXYZToAirplaneXForwardZDown>
-      <gazeboXYZToNED>0 0 0 3.141593 0 0</gazeboXYZToNED>
+      <modelXYZToAirplaneXForwardZDown degrees="true">0 0 0 180 0 0</modelXYZToAirplaneXForwardZDown>
+      <gazeboXYZToNED degrees="true">0 0 0 180 0 90</gazeboXYZToNED>
 
       <!-- Sensors -->
       <imuName>imu_sensor</imuName>

--- a/Gazebo/models/wildthumper_with_lidar/model.sdf
+++ b/Gazebo/models/wildthumper_with_lidar/model.sdf
@@ -200,7 +200,7 @@
     <link name='front_left_motor_asm_link'>
       <pose relative_to='front_left_motor_asm_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0.025 0 90 0 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>2.723333333333334e-05</ixx>
@@ -212,7 +212,7 @@
         </inertia>
       </inertial>
       <collision name='front_left_motor_asm_link_collision'>
-        <pose>0 0 0 0 1.570796326794897 0</pose>
+        <pose degrees="true">0 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.064</length>
@@ -221,7 +221,7 @@
         </geometry>
       </collision>
       <collision name='front_left_motor_asm_link_collision_1'>
-        <pose>0 0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0.025 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -272,7 +272,7 @@
     <link name='front_left_wheel_link'>
       <pose relative_to='front_left_wheel_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <mass>0.19</mass>
         <inertia>
           <ixx>0.0002022409166666667</ixx>
@@ -284,7 +284,7 @@
         </inertia>
       </inertial>
       <collision name='front_left_wheel_link_collision'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.062</length>
@@ -304,7 +304,7 @@
         </surface>
       </collision>
       <collision name='front_left_wheel_link_fixed_joint_lump__front_left_wheel_adapter_link_collision_1'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.024</length>
@@ -313,7 +313,7 @@
         </geometry>
       </collision>
       <collision name='front_left_wheel_link_fixed_joint_lump__front_left_wheel_rim_link_collision_2'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -416,7 +416,7 @@
     <link name='front_right_motor_asm_link'>
       <pose relative_to='front_right_motor_asm_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 -0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 -0.025 0 90 0 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>2.723333333333334e-05</ixx>
@@ -428,7 +428,7 @@
         </inertia>
       </inertial>
       <collision name='front_right_motor_asm_link_collision'>
-        <pose>0 0 0 0 1.570796326794897 0</pose>
+        <pose degrees="true">0 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.064</length>
@@ -437,7 +437,7 @@
         </geometry>
       </collision>
       <collision name='front_right_motor_asm_link_collision_1'>
-        <pose>0 -0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 -0.025 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -488,7 +488,7 @@
     <link name='front_right_wheel_link'>
       <pose relative_to='front_right_wheel_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <mass>0.19</mass>
         <inertia>
           <ixx>0.0002022409166666667</ixx>
@@ -500,7 +500,7 @@
         </inertia>
       </inertial>
       <collision name='front_right_wheel_link_collision'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.062</length>
@@ -520,7 +520,7 @@
         </surface>
       </collision>
       <collision name='front_right_wheel_link_fixed_joint_lump__front_right_wheel_adapter_link_collision_1'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.024</length>
@@ -529,7 +529,7 @@
         </geometry>
       </collision>
       <collision name='front_right_wheel_link_fixed_joint_lump__front_right_wheel_rim_link_collision_2'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -694,7 +694,7 @@
     <link name='mid_left_motor_asm_link'>
       <pose relative_to='mid_left_motor_asm_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0.025 0 90 0 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>2.723333333333334e-05</ixx>
@@ -706,7 +706,7 @@
         </inertia>
       </inertial>
       <collision name='mid_left_motor_asm_link_collision'>
-        <pose>0 0 0 0 1.570796326794897 0</pose>
+        <pose degrees="true">0 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.064</length>
@@ -715,7 +715,7 @@
         </geometry>
       </collision>
       <collision name='mid_left_motor_asm_link_collision_1'>
-        <pose>0 0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0.025 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -766,7 +766,7 @@
     <link name='mid_left_wheel_link'>
       <pose relative_to='mid_left_wheel_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <mass>0.19</mass>
         <inertia>
           <ixx>0.0002022409166666667</ixx>
@@ -778,7 +778,7 @@
         </inertia>
       </inertial>
       <collision name='mid_left_wheel_link_collision'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.062</length>
@@ -798,7 +798,7 @@
         </surface>
       </collision>
       <collision name='mid_left_wheel_link_fixed_joint_lump__mid_left_wheel_adapter_link_collision_1'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.024</length>
@@ -807,7 +807,7 @@
         </geometry>
       </collision>
       <collision name='mid_left_wheel_link_fixed_joint_lump__mid_left_wheel_rim_link_collision_2'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -910,7 +910,7 @@
     <link name='mid_right_motor_asm_link'>
       <pose relative_to='mid_right_motor_asm_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 -0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 -0.025 0 90 0 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>2.723333333333334e-05</ixx>
@@ -922,7 +922,7 @@
         </inertia>
       </inertial>
       <collision name='mid_right_motor_asm_link_collision'>
-        <pose>0 0 0 0 1.570796326794897 0</pose>
+        <pose degrees="true">0 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.064</length>
@@ -931,7 +931,7 @@
         </geometry>
       </collision>
       <collision name='mid_right_motor_asm_link_collision_1'>
-        <pose>0 -0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 -0.025 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -982,7 +982,7 @@
     <link name='mid_right_wheel_link'>
       <pose relative_to='mid_right_wheel_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <mass>0.19</mass>
         <inertia>
           <ixx>0.0002022409166666667</ixx>
@@ -994,7 +994,7 @@
         </inertia>
       </inertial>
       <collision name='mid_right_wheel_link_collision'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.062</length>
@@ -1014,7 +1014,7 @@
         </surface>
       </collision>
       <collision name='mid_right_wheel_link_fixed_joint_lump__mid_right_wheel_adapter_link_collision_1'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.024</length>
@@ -1023,7 +1023,7 @@
         </geometry>
       </collision>
       <collision name='mid_right_wheel_link_fixed_joint_lump__mid_right_wheel_rim_link_collision_2'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -1250,7 +1250,7 @@
     <link name='rear_left_motor_asm_link'>
       <pose relative_to='rear_left_motor_asm_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0.025 0 90 0 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>2.723333333333334e-05</ixx>
@@ -1262,7 +1262,7 @@
         </inertia>
       </inertial>
       <collision name='rear_left_motor_asm_link_collision'>
-        <pose>0 0 0 0 1.570796326794897 0</pose>
+        <pose degrees="true">0 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.064</length>
@@ -1271,7 +1271,7 @@
         </geometry>
       </collision>
       <collision name='rear_left_motor_asm_link_collision_1'>
-        <pose>0 0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0.025 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -1322,7 +1322,7 @@
     <link name='rear_left_wheel_link'>
       <pose relative_to='rear_left_wheel_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <mass>0.19</mass>
         <inertia>
           <ixx>0.0002022409166666667</ixx>
@@ -1334,7 +1334,7 @@
         </inertia>
       </inertial>
       <collision name='rear_left_wheel_link_collision'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.062</length>
@@ -1354,7 +1354,7 @@
         </surface>
       </collision>
       <collision name='rear_left_wheel_link_fixed_joint_lump__rear_left_wheel_adapter_link_collision_1'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.024</length>
@@ -1363,7 +1363,7 @@
         </geometry>
       </collision>
       <collision name='rear_left_wheel_link_fixed_joint_lump__rear_left_wheel_rim_link_collision_2'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -1466,7 +1466,7 @@
     <link name='rear_right_motor_asm_link'>
       <pose relative_to='rear_right_motor_asm_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 -0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 -0.025 0 90 0 0</pose>
         <mass>0.1</mass>
         <inertia>
           <ixx>2.723333333333334e-05</ixx>
@@ -1478,7 +1478,7 @@
         </inertia>
       </inertial>
       <collision name='rear_right_motor_asm_link_collision'>
-        <pose>0 0 0 0 1.570796326794897 0</pose>
+        <pose degrees="true">0 0 0 0 90 0</pose>
         <geometry>
           <cylinder>
             <length>0.064</length>
@@ -1487,7 +1487,7 @@
         </geometry>
       </collision>
       <collision name='rear_right_motor_asm_link_collision_1'>
-        <pose>0 -0.025 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 -0.025 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -1538,7 +1538,7 @@
     <link name='rear_right_wheel_link'>
       <pose relative_to='rear_right_wheel_joint'>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <mass>0.19</mass>
         <inertia>
           <ixx>0.0002022409166666667</ixx>
@@ -1550,7 +1550,7 @@
         </inertia>
       </inertial>
       <collision name='rear_right_wheel_link_collision'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.062</length>
@@ -1570,7 +1570,7 @@
         </surface>
       </collision>
       <collision name='rear_right_wheel_link_fixed_joint_lump__rear_right_wheel_adapter_link_collision_1'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.024</length>
@@ -1579,7 +1579,7 @@
         </geometry>
       </collision>
       <collision name='rear_right_wheel_link_fixed_joint_lump__rear_right_wheel_rim_link_collision_2'>
-        <pose>0 0 0 1.570796326794896 0 0</pose>
+        <pose degrees="true">0 0 0 90 0 0</pose>
         <geometry>
           <cylinder>
             <length>0.05</length>
@@ -1738,7 +1738,7 @@
         </inertia>
       </inertial>
       <sensor name="imu_sensor" type="imu">
-        <pose>0 0 0 3.141593 0 0</pose>
+        <pose degrees="true">0 0 0 180 0 0</pose>
         <always_on>1</always_on>
         <update_rate>1000.0</update_rate>
       </sensor>
@@ -1921,8 +1921,8 @@
 
         Vehicle is oriented x-forward, y-left, z-up
       -->
-      <modelXYZToAirplaneXForwardZDown>0 0 0 3.141593 0 0</modelXYZToAirplaneXForwardZDown>
-      <gazeboXYZToNED>0 0 0 3.141593 0 0</gazeboXYZToNED>
+      <modelXYZToAirplaneXForwardZDown degrees="true">0 0 0 180 0 0</modelXYZToAirplaneXForwardZDown>
+      <gazeboXYZToNED degrees="true">0 0 0 180 0 90</gazeboXYZToNED>
 
       <!-- Sensors -->
       <imuName>imu_sensor</imuName>

--- a/Gazebo/models/wildthumper_with_lidar/model.sdf
+++ b/Gazebo/models/wildthumper_with_lidar/model.sdf
@@ -1869,7 +1869,7 @@
     </joint>
 
     <!-- plugins -->
-    <plugin filename="libgz-sim-joint-state-publisher-system.so"
+    <plugin filename="gz-sim-joint-state-publisher-system"
       name="gz::sim::systems::JointStatePublisher">
     </plugin>
     <plugin
@@ -1879,32 +1879,32 @@
       <robot_base_frame>base_link</robot_base_frame>
       <dimensions>3</dimensions>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>front_left_wheel_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>front_right_wheel_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>mid_left_wheel_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>mid_right_wheel_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>rear_left_wheel_joint</joint_name>
     </plugin>
-    <plugin filename="libgz-sim-apply-joint-force-system.so"
+    <plugin filename="gz-sim-apply-joint-force-system"
       name="gz::sim::systems::ApplyJointForce">
       <joint_name>rear_right_wheel_joint</joint_name>
     </plugin>
 
-    <plugin name="ArduPilotPlugin" filename="libArduPilotPlugin.so">
+    <plugin name="ArduPilotPlugin" filename="ArduPilotPlugin">
       <!-- Port settings -->
       <fdm_addr>127.0.0.1</fdm_addr>
       <fdm_port_in>9002</fdm_port_in>

--- a/Gazebo/worlds/alti_transition_runway.sdf
+++ b/Gazebo/worlds/alti_transition_runway.sdf
@@ -1,16 +1,16 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
   <world name="alti_transition_runway">
-    <plugin filename="libgz-sim-physics-system.so"
+    <plugin filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
     </plugin>
-    <plugin filename="libgz-sim-user-commands-system.so"
+    <plugin filename="gz-sim-user-commands-system"
       name="gz::sim::systems::UserCommands">
     </plugin>
-    <plugin filename="libgz-sim-scene-broadcaster-system.so"
+    <plugin filename="gz-sim-scene-broadcaster-system"
       name="gz::sim::systems::SceneBroadcaster">
     </plugin>
-    <plugin filename="libgz-sim-imu-system.so"
+    <plugin filename="gz-sim-imu-system"
       name="gz::sim::systems::Imu">
     </plugin>
 

--- a/Gazebo/worlds/alti_transition_runway.sdf
+++ b/Gazebo/worlds/alti_transition_runway.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
-  <world name="alti_transition_runway">
+  <world name="runway">
     <plugin filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
     </plugin>

--- a/Gazebo/worlds/bicopter_runway.sdf
+++ b/Gazebo/worlds/bicopter_runway.sdf
@@ -120,7 +120,7 @@
     </model> -->
 
     <include>
-      <pose degrees="true">0 0 0 0 0 90</pose>
+      <pose degrees="true">-29 545 0 0 0 363</pose>
       <uri>model://runway</uri>
     </include>
 

--- a/Gazebo/worlds/daf_truck_runway.sdf
+++ b/Gazebo/worlds/daf_truck_runway.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
-  <world name="daf_truck_runway">
+  <world name="runway">
     <plugin filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
     </plugin>

--- a/Gazebo/worlds/daf_truck_runway.sdf
+++ b/Gazebo/worlds/daf_truck_runway.sdf
@@ -1,16 +1,16 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
   <world name="daf_truck_runway">
-    <plugin filename="libgz-sim-physics-system.so"
+    <plugin filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
     </plugin>
-    <plugin filename="libgz-sim-user-commands-system.so"
+    <plugin filename="gz-sim-user-commands-system"
       name="gz::sim::systems::UserCommands">
     </plugin>
-    <plugin filename="libgz-sim-scene-broadcaster-system.so"
+    <plugin filename="gz-sim-scene-broadcaster-system"
       name="gz::sim::systems::SceneBroadcaster">
     </plugin>
-    <plugin filename="libgz-sim-imu-system.so"
+    <plugin filename="gz-sim-imu-system"
       name="gz::sim::systems::Imu">
     </plugin>
 

--- a/Gazebo/worlds/hexapod_copter_runway.sdf
+++ b/Gazebo/worlds/hexapod_copter_runway.sdf
@@ -39,12 +39,13 @@
     </light>
 
     <include>
+      <pose degrees="true">-29 545 0 0 0 363</pose>
       <uri>model://runway</uri>
     </include>
 
     <!-- Hexapod copter -->
     <include>
-      <pose>0 0 0.12 0 0 1.57079632</pose>
+      <pose degrees="true">0 0 0.12 0 0 90</pose>
       <uri>model://hexapod_copter</uri>
     </include>
 

--- a/Gazebo/worlds/quadruped_runway.sdf
+++ b/Gazebo/worlds/quadruped_runway.sdf
@@ -1,16 +1,16 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
   <world name="quadruped_runway">
-    <plugin filename="libgz-sim-physics-system.so"
+    <plugin filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
     </plugin>
-    <plugin filename="libgz-sim-user-commands-system.so"
+    <plugin filename="gz-sim-user-commands-system"
       name="gz::sim::systems::UserCommands">
     </plugin>
-    <plugin filename="libgz-sim-scene-broadcaster-system.so"
+    <plugin filename="gz-sim-scene-broadcaster-system"
       name="gz::sim::systems::SceneBroadcaster">
     </plugin>
-    <plugin filename="libgz-sim-imu-system.so"
+    <plugin filename="gz-sim-imu-system"
       name="gz::sim::systems::Imu">
     </plugin>
 

--- a/Gazebo/worlds/quadruped_runway.sdf
+++ b/Gazebo/worlds/quadruped_runway.sdf
@@ -35,6 +35,7 @@
     </light>
 
     <include>
+      <pose degrees="true">-29 545 0 0 0 363</pose>
       <uri>model://runway</uri>
     </include>
 
@@ -67,7 +68,7 @@
 
     <!-- Quadruped rover -->
     <include>
-      <pose>0 0 0.12 0 0 0</pose>
+      <pose degrees="true">0 0 0.12 0 0 90</pose>
       <uri>model://quadruped</uri>
     </include>
 

--- a/Gazebo/worlds/quadruped_runway.sdf
+++ b/Gazebo/worlds/quadruped_runway.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
-  <world name="quadruped_runway">
+  <world name="runway">
     <plugin filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
     </plugin>

--- a/Gazebo/worlds/rover_playpen.sdf
+++ b/Gazebo/worlds/rover_playpen.sdf
@@ -82,7 +82,7 @@
     </model>
     
     <include>
-      <pose>0 0 0 0 0 1.570796</pose>
+      <pose degrees="true">0 0 0 0 0 90</pose>
       <uri>model://rover_playpen</uri>
     </include>
 

--- a/Gazebo/worlds/rover_playpen.sdf
+++ b/Gazebo/worlds/rover_playpen.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
-  <world name="rover_playpen">
+  <world name="playpen">
     <plugin filename="gz-sim-physics-system"
             name="gz::sim::systems::Physics">
     </plugin>

--- a/Gazebo/worlds/sawppy_playpen.sdf
+++ b/Gazebo/worlds/sawppy_playpen.sdf
@@ -40,11 +40,12 @@
     </light>
 
     <include>
+      <pose degrees="true">0 0 0 0 0 90</pose>
       <uri>model://rover_playpen</uri>
     </include>
 
     <include>
-      <pose>0 0 0.25 0 0 0</pose>
+      <pose degrees="true">0 0 0.25 0 0 90</pose>
       <uri>model://sawppy</uri>
     </include>
 

--- a/Gazebo/worlds/sawppy_playpen.sdf
+++ b/Gazebo/worlds/sawppy_playpen.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
-  <world name="sawppy_playpen">
+  <world name="playpen">
     <physics name="1ms" type="ignore">
       <max_step_size>0.001</max_step_size>
       <real_time_factor>1</real_time_factor>

--- a/Gazebo/worlds/skycat_runway.sdf
+++ b/Gazebo/worlds/skycat_runway.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
-  <world name="skycat_runway">
+  <world name="runway">
     <plugin filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
     </plugin>

--- a/Gazebo/worlds/skycat_runway.sdf
+++ b/Gazebo/worlds/skycat_runway.sdf
@@ -1,16 +1,16 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
   <world name="skycat_runway">
-    <plugin filename="libgz-sim-physics-system.so"
+    <plugin filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
     </plugin>
-    <plugin filename="libgz-sim-user-commands-system.so"
+    <plugin filename="gz-sim-user-commands-system"
       name="gz::sim::systems::UserCommands">
     </plugin>
-    <plugin filename="libgz-sim-scene-broadcaster-system.so"
+    <plugin filename="gz-sim-scene-broadcaster-system"
       name="gz::sim::systems::SceneBroadcaster">
     </plugin>
-    <plugin filename="libgz-sim-imu-system.so"
+    <plugin filename="gz-sim-imu-system"
       name="gz::sim::systems::Imu">
     </plugin>
 

--- a/Gazebo/worlds/skycat_runway.sdf
+++ b/Gazebo/worlds/skycat_runway.sdf
@@ -35,11 +35,12 @@
     </light>
 
     <include>
+      <pose degrees="true">-29 545 0 0 0 363</pose>
       <uri>model://runway</uri>
     </include>
 
     <include>
-      <pose>0 0 0.15 0 0 0</pose>
+      <pose degrees="true">0 0 0.15 0 0 90</pose>
       <uri>model://skycat_tvbs</uri>
     </include>
 

--- a/Gazebo/worlds/skywalker_x8_quad_runway.sdf
+++ b/Gazebo/worlds/skywalker_x8_quad_runway.sdf
@@ -35,12 +35,13 @@
     </light>
 
     <include>
+      <pose degrees="true">-29 545 0 0 0 363</pose>
       <uri>model://runway</uri>
     </include>
 
     <!-- SkyWalker X8 model -->
     <include>
-      <pose>0 0 0.2 0 0 0</pose>
+      <pose degrees="true">0 0 0.2 0 0 90</pose>
       <uri>model://skywalker_x8_quad</uri>
     </include>
 

--- a/Gazebo/worlds/skywalker_x8_quad_runway.sdf
+++ b/Gazebo/worlds/skywalker_x8_quad_runway.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
-  <world name="skywalker_x8_quad_runway">
+  <world name="runway">
     <plugin filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
     </plugin>

--- a/Gazebo/worlds/skywalker_x8_quad_runway.sdf
+++ b/Gazebo/worlds/skywalker_x8_quad_runway.sdf
@@ -1,16 +1,16 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
   <world name="skywalker_x8_quad_runway">
-    <plugin filename="libgz-sim-physics-system.so"
+    <plugin filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
     </plugin>
-    <plugin filename="libgz-sim-user-commands-system.so"
+    <plugin filename="gz-sim-user-commands-system"
       name="gz::sim::systems::UserCommands">
     </plugin>
-    <plugin filename="libgz-sim-scene-broadcaster-system.so"
+    <plugin filename="gz-sim-scene-broadcaster-system"
       name="gz::sim::systems::SceneBroadcaster">
     </plugin>
-    <plugin filename="libgz-sim-imu-system.so"
+    <plugin filename="gz-sim-imu-system"
       name="gz::sim::systems::Imu">
     </plugin>
 

--- a/Gazebo/worlds/skywalker_x8_runway.sdf
+++ b/Gazebo/worlds/skywalker_x8_runway.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
-  <world name="skywalker_x8_runway">
+  <world name="runway">
     <plugin filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
     </plugin>

--- a/Gazebo/worlds/skywalker_x8_runway.sdf
+++ b/Gazebo/worlds/skywalker_x8_runway.sdf
@@ -1,16 +1,16 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
   <world name="skywalker_x8_runway">
-    <plugin filename="libgz-sim-physics-system.so"
+    <plugin filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
     </plugin>
-    <plugin filename="libgz-sim-user-commands-system.so"
+    <plugin filename="gz-sim-user-commands-system"
       name="gz::sim::systems::UserCommands">
     </plugin>
-    <plugin filename="libgz-sim-scene-broadcaster-system.so"
+    <plugin filename="gz-sim-scene-broadcaster-system"
       name="gz::sim::systems::SceneBroadcaster">
     </plugin>
-    <plugin filename="libgz-sim-imu-system.so"
+    <plugin filename="gz-sim-imu-system"
       name="gz::sim::systems::Imu">
     </plugin>
 

--- a/Gazebo/worlds/skywalker_x8_runway.sdf
+++ b/Gazebo/worlds/skywalker_x8_runway.sdf
@@ -35,13 +35,13 @@
     </light>
 
     <include>
+      <pose degrees="true">-29 545 0 0 0 363</pose>
       <uri>model://runway</uri>
     </include>
 
     <!-- SkyWalker X8 model -->
     <include>
-      <!-- <pose>0 0 0.4 0 -1.5707963 0</pose> -->
-      <pose>0 0 0.2 0 0 0</pose>
+      <pose degrees="true">0 0 0.2 0 0 90</pose>
       <uri>model://skywalker_x8</uri>
     </include>
 

--- a/Gazebo/worlds/sonoma_raceway.sdf
+++ b/Gazebo/worlds/sonoma_raceway.sdf
@@ -1,16 +1,16 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
   <world name="sonoma_raceway">
-    <plugin filename="libgz-sim-physics-system.so"
+    <plugin filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
     </plugin>
-    <plugin filename="libgz-sim-user-commands-system.so"
+    <plugin filename="gz-sim-user-commands-system"
       name="gz::sim::systems::UserCommands">
     </plugin>
-    <plugin filename="libgz-sim-scene-broadcaster-system.so"
+    <plugin filename="gz-sim-scene-broadcaster-system"
       name="gz::sim::systems::SceneBroadcaster">
     </plugin>
-    <plugin filename="libgz-sim-imu-system.so"
+    <plugin filename="gz-sim-imu-system"
       name="gz::sim::systems::Imu">
     </plugin>
 

--- a/Gazebo/worlds/sonoma_raceway.sdf
+++ b/Gazebo/worlds/sonoma_raceway.sdf
@@ -47,28 +47,33 @@
 
     <!-- 
       A vehicle on the Sonoma Raceway start grid has a
-      heading of 0.959931 rad (-55 deg)
+      heading of 145 deg
 
-      <pose>0 0 0 0 0 0.959931089</pose>
+      <pose degrees="true">0 0 0 0 0 145</pose>
 
       Below are examples for loading different vehicles onto
       the start grid. 
       -->
 
     <!-- <include>
-      <pose>0 0 0.15 0 0 0.959931089</pose>
+      <pose degrees="true">0 0 1.0 0 0 145</pose>
+      <uri>model://daf_xf_450_tractor</uri>
+    </include> -->
+
+    <!-- <include>
+      <pose degrees="true">0 0 0.1 0 0 145</pose>
       <uri>model://wildthumper</uri>
     </include> -->
 
     <!-- <include>
-      <pose>0 0 0.15 0 0 0.959931089</pose>
-      <uri>model://iris_with_standoffs</uri>
+      <pose degrees="true">0 0 0.1 0 0 145</pose>
+      <uri>model://iris_with_ardupilot</uri>
     </include> -->
 
-    <!-- <include>
-      <pose>0 0 0.15 0 0 0.959931089</pose>
+    <include>
+      <pose degrees="true">0 0 0.15 0 0 145</pose>
       <uri>model://skywalker_x8_quad</uri>
-    </include> -->
+    </include>
 
   </world>
 </sdf>

--- a/Gazebo/worlds/sonoma_raceway.sdf
+++ b/Gazebo/worlds/sonoma_raceway.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
-  <world name="sonoma_raceway">
+  <world name="raceway">
     <plugin filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
     </plugin>

--- a/Gazebo/worlds/swan_k1_hwing_runway.sdf
+++ b/Gazebo/worlds/swan_k1_hwing_runway.sdf
@@ -92,12 +92,12 @@
     </model>
 
     <include>
+      <pose degrees="true">-29 545 0 0 0 363</pose>
       <uri>model://runway</uri>
     </include>
 
     <include>
-      <!-- <pose>0 0 0.3 0 0 0</pose> -->
-      <pose>0 0 0.3 0 -1.570796 0</pose>
+      <pose degrees="true">0 0 0.3 0 -90 0</pose>
       <uri>model://swan_k1_hwing</uri>
     </include>
 

--- a/Gazebo/worlds/swan_k1_hwing_runway.sdf
+++ b/Gazebo/worlds/swan_k1_hwing_runway.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
-  <world name="swan_k1_hwing_runway">
+  <world name="runway">
     <physics name="1ms" type="ignore">
       <max_step_size>0.001</max_step_size>
       <real_time_factor>1</real_time_factor>

--- a/Gazebo/worlds/truck_quadplane_landing.sdf.erb
+++ b/Gazebo/worlds/truck_quadplane_landing.sdf.erb
@@ -40,7 +40,7 @@
 
 <?xml version="1.0" ?>
 <sdf version="1.7">
-  <world name="truck_quadplane_landing">
+  <world name="runway">
     <plugin filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
     </plugin>

--- a/Gazebo/worlds/truck_quadplane_landing.sdf.erb
+++ b/Gazebo/worlds/truck_quadplane_landing.sdf.erb
@@ -41,16 +41,16 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
   <world name="truck_quadplane_landing">
-    <plugin filename="libgz-sim-physics-system.so"
+    <plugin filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
     </plugin>
-    <plugin filename="libgz-sim-user-commands-system.so"
+    <plugin filename="gz-sim-user-commands-system"
       name="gz::sim::systems::UserCommands">
     </plugin>
-    <plugin filename="libgz-sim-scene-broadcaster-system.so"
+    <plugin filename="gz-sim-scene-broadcaster-system"
       name="gz::sim::systems::SceneBroadcaster">
     </plugin>
-    <plugin filename="libgz-sim-imu-system.so"
+    <plugin filename="gz-sim-imu-system"
       name="gz::sim::systems::Imu">
     </plugin>
 

--- a/Gazebo/worlds/wildthumper_playpen.sdf
+++ b/Gazebo/worlds/wildthumper_playpen.sdf
@@ -59,12 +59,12 @@
     </spherical_coordinates>
 
     <include>
-      <pose degrees="true">0 0 0 0 0 0</pose>
+      <pose degrees="true">0 0 0 0 0 90</pose>
       <uri>model://rover_playpen</uri>
     </include>
 
     <include>
-      <pose degrees="true">0 0 0.15 0 0 0</pose>
+      <pose degrees="true">0 0 0.15 0 0 90</pose>
       <uri>model://wildthumper</uri>
     </include>
 

--- a/Gazebo/worlds/wildthumper_runway.sdf
+++ b/Gazebo/worlds/wildthumper_runway.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
-  <world name="wildthumper_runway">
+  <world name="runway">
     <plugin filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
     </plugin>

--- a/Gazebo/worlds/wildthumper_runway.sdf
+++ b/Gazebo/worlds/wildthumper_runway.sdf
@@ -35,12 +35,13 @@
     </light>
 
     <include>
+      <pose degrees="true">-29 545 0 0 0 363</pose>
       <uri>model://runway</uri>
     </include>
 
     <!-- Stand (move to origin to support rover)) -->
     <model name="stand">
-      <pose>0 5 0.05 0 0 0</pose>
+      <pose degrees="true">0 5 0.05 0 0 90</pose>
       <static>1</static>
       <link name="base_link">
         <visual name="visual">
@@ -104,7 +105,7 @@
 
     <!-- Wild Thumper rover -->
     <include>
-      <pose>0 0 0.15 0 0 0</pose>
+      <pose degrees="true">0 0 0.15 0 0 90</pose>
       <uri>model://wildthumper</uri>
     </include>
 

--- a/Gazebo/worlds/wildthumper_runway.sdf
+++ b/Gazebo/worlds/wildthumper_runway.sdf
@@ -1,16 +1,16 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
   <world name="wildthumper_runway">
-    <plugin filename="libgz-sim-physics-system.so"
+    <plugin filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
     </plugin>
-    <plugin filename="libgz-sim-user-commands-system.so"
+    <plugin filename="gz-sim-user-commands-system"
       name="gz::sim::systems::UserCommands">
     </plugin>
-    <plugin filename="libgz-sim-scene-broadcaster-system.so"
+    <plugin filename="gz-sim-scene-broadcaster-system"
       name="gz::sim::systems::SceneBroadcaster">
     </plugin>
-    <plugin filename="libgz-sim-imu-system.so"
+    <plugin filename="gz-sim-imu-system"
       name="gz::sim::systems::Imu">
     </plugin>
 


### PR DESCRIPTION
Correct orientation and ENU to NED transforms for remaining models and worlds.

- Follow up to https://github.com/ArduPilot/SITL_Models/pull/114.
- The mapping error between world frames becomes apparent when enabling the NavSat and Magnetometer sensors.

### Details

- Update transforms in ArduPilot plugin xml.
- Update orientation of vehicle model in world.
- Use degrees rather than radians in pose when this simplifies.

### Checklist

Models
- [x] alti_transition_quad
- [x] bicopter
- [x] bicopter_with_ardupilot
- [x] blueboat
- [x] catamaran
- [x] daf_xf_450_flatbed_trailer
- [x] daf_xf_450_tractor
- [x] hexapod_copter
- [x] quadruped
- [x] sawppy
- [x] skycat_tvbs
- [x] skywalker_x8
- [x] skywalker_x8_quad
- [x] swan_k1_hwing
- [x] wildthumper
- [x] wildthumper_with_lidar

Environment Models
- [x] rover_playpen
- [x] sonoma_raceway

Worlds
- [x] alti_transition_runway
- [x] bicopter_runway
- [x] catamaran_waves
- [x] daf_truck_runway
- [x] hexapod_copter_runway
- [x] quadruped_runway
- [x] rover_playpen
- [x] swappy_playpen
- [x] skycat_runway
- [x] skywalker_x8_quad_runway
- [x] skywalker_x8_runway
- [x] sonoma_raceway
- [x] swan_k1_hwing_runway
- [x] truck_quadplane_landing (erb)
- [x] wildthumper_playpen
- [x] wildthumper_runway

Scripts
- [x] runway-alti_transition_quad.sh
- [x] runway-daf_xf_450_tractor
- [x] sonoma-iris
- [x] sonoma-skywalker_x8_quad
- [x] sonoma-truck
- [x] sonoma-wildthumper
- [x] truck-quadplane-landing 

