### PR TITLE
Gazebo: use radians for lidar min_angle and max_angle attributes

### DIFF
--- a/Gazebo/models/wildthumper_with_lidar/model.sdf
+++ b/Gazebo/models/wildthumper_with_lidar/model.sdf
@@ -1826,8 +1826,8 @@
             <horizontal>
               <samples>360</samples>
               <resolution>1</resolution>
-              <min_angle degrees="true">-180</min_angle>
-              <max_angle degrees="true">180</max_angle>
+              <min_angle>-3.14159265</min_angle>
+              <max_angle>3.14159265</max_angle>
             </horizontal>
             <vertical>
               <samples>1</samples>


### PR DESCRIPTION
Change min and max angle elements in lidar sensor to use radians as there is no `degrees` attribute.