### PR TITLE
Rover: remove deprecated <script> material element from model

### DIFF
--- a/Gazebo/models/wildthumper/model.sdf
+++ b/Gazebo/models/wildthumper/model.sdf
@@ -32,10 +32,6 @@
           </box>
         </geometry>
         <material>
-          <script>
-            <name>Gazebo/Orange</name>
-            <uri>file://media/materials/scripts/gazebo.material</uri>
-          </script>
           <diffuse>1 0.3125 0 1</diffuse>
           <ambient>1 0.3125 0 1</ambient>
         </material>

--- a/Gazebo/models/wildthumper_with_lidar/model.sdf
+++ b/Gazebo/models/wildthumper_with_lidar/model.sdf
@@ -32,10 +32,6 @@
           </box>
         </geometry>
         <material>
-          <script>
-            <name>Gazebo/Orange</name>
-            <uri>file://media/materials/scripts/gazebo.material</uri>
-          </script>
           <diffuse>1 0.3125 0 1</diffuse>
           <ambient>1 0.3125 0 1</ambient>
         </material>


### PR DESCRIPTION
Fixes #135 

## Testing

Tested with Gazebo Harmonic built from source on macOS: https://github.com/gazebosim/gz-sim/commit/d6067cdc1cccc0d1ff80c90c9614dfbd6a16a77c

Model loads correctly in the playpen world.

<img width="1312" alt="wildthumper-material" src="https://github.com/ArduPilot/SITL_Models/assets/24916364/14675578-5f15-40ea-92b1-ec3ba55db1f8">

